### PR TITLE
Release v0.5.0: Profile & Extended Attribute Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 01 Apr 2026
+
+### Added
+
+- **JSON profile serialization** -- `model_to_dict()` now includes a `"profiles"`
+  key serializing `Profile` objects with type-name strings for class keys and
+  Python type-name strings for attribute types. `model_from_dict()` reconstructs
+  profiles and calls `apply_profile()` before adding elements. Specialization,
+  extended attributes, and `model.validate()` all survive JSON round-trip.
+- **XML profile serialization** -- `serialize_model()` emits
+  `<propertyDefinitions>` for profile attribute extensions; `serialize_element()`
+  emits a `specialization` attribute and `<properties>` sub-elements for
+  extended attributes. `deserialize_model()` reconstructs a synthetic profile
+  from property definitions and element specializations, applying it before
+  adding elements.
+- **Round-trip integrity tests** -- comprehensive idempotency and edge-case
+  coverage for both JSON and XML profile serialization, including dict
+  idempotency, XML element-data stability, empty-attributes noise checks,
+  and specializations-only profile round-trips.
+
 ## [0.4.1] - 01 Apr 2026
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "etcion"
-version = "0.4.1"
+version = "0.5.0"
 description = "Architecture as code — build, query, validate, and analyze enterprise architecture models in Python"
 readme = "README.md"
 license = "MIT"

--- a/src/etcion/serialization/json.py
+++ b/src/etcion/serialization/json.py
@@ -7,12 +7,63 @@ from __future__ import annotations
 
 from typing import Any
 
-from etcion.metamodel.concepts import Concept, Relationship
+from etcion.metamodel.concepts import Concept, Element, Relationship
 from etcion.metamodel.model import Model
+from etcion.metamodel.profiles import Profile
 from etcion.serialization.registry import TYPE_REGISTRY
 
 # Reverse lookup: _type_name string -> concrete class
 _NAME_TO_TYPE: dict[str, type[Concept]] = {desc.xml_tag: cls for cls, desc in TYPE_REGISTRY.items()}
+
+
+def _serialize_profile(profile: Profile) -> dict[str, Any]:
+    """Serialize a Profile to a dict using ArchiMate type-name strings as keys.
+
+    Each class key in ``specializations`` and ``attribute_extensions`` is
+    replaced with its ``xml_tag`` string from :data:`TYPE_REGISTRY`.  Python
+    ``type`` values in ``attribute_extensions`` are replaced with their
+    ``__name__`` strings (e.g. ``"str"``, ``"float"``).
+    """
+    type_to_name: dict[type, str] = {cls: desc.xml_tag for cls, desc in TYPE_REGISTRY.items()}
+
+    serialized_specs: dict[str, list[str]] = {}
+    for cls, names in profile.specializations.items():
+        serialized_specs[type_to_name[cls]] = names
+
+    serialized_attrs: dict[str, dict[str, str]] = {}
+    for cls, attrs in profile.attribute_extensions.items():
+        serialized_attrs[type_to_name[cls]] = {
+            attr_name: attr_type.__name__ for attr_name, attr_type in attrs.items()
+        }
+
+    return {
+        "name": profile.name,
+        "specializations": serialized_specs,
+        "attribute_extensions": serialized_attrs,
+    }
+
+
+def _deserialize_profile(data: dict[str, Any]) -> Profile:
+    """Reconstruct a Profile from a serialized dict.
+
+    Type-name strings are resolved back to classes via :data:`_NAME_TO_TYPE`.
+    Attribute type strings are resolved via a restricted allow-list of safe
+    built-in types (``str``, ``int``, ``float``, ``bool``).
+    """
+    _ALLOWED_TYPES: dict[str, type] = {"str": str, "int": int, "float": float, "bool": bool}
+
+    specs: dict[type[Element], list[str]] = {}
+    for type_name, names in data.get("specializations", {}).items():
+        specs[_NAME_TO_TYPE[type_name]] = names  # type: ignore[index]
+
+    attrs: dict[type[Element], dict[str, type]] = {}
+    for type_name, attr_map in data.get("attribute_extensions", {}).items():
+        cls = _NAME_TO_TYPE[type_name]
+        attrs[cls] = {  # type: ignore[index]
+            attr_name: _ALLOWED_TYPES[type_str] for attr_name, type_str in attr_map.items()
+        }
+
+    return Profile(name=data["name"], specializations=specs, attribute_extensions=attrs)
 
 
 def _serialize_concept(concept: Concept) -> dict[str, Any]:
@@ -40,16 +91,24 @@ def model_to_dict(model: Model) -> dict[str, Any]:
     The returned structure is::
 
         {
+            "_schema_version": "1.0",
+            "profiles": [<profile dict>, ...],
             "elements": [<element dict>, ...],
             "relationships": [<relationship dict>, ...],
         }
 
-    Every entry carries a ``_type`` key whose value is the ArchiMate
-    type name string (e.g. ``"BusinessActor"``), used as a discriminator
-    during deserialization.
+    Every element and relationship entry carries a ``_type`` key whose value
+    is the ArchiMate type name string (e.g. ``"BusinessActor"``), used as a
+    discriminator during deserialization.
+
+    Each profile dict has ``name``, ``specializations``, and
+    ``attribute_extensions`` keys, with class keys serialized as
+    ArchiMate type-name strings and Python type values serialized as
+    type-name strings (e.g. ``"str"``, ``"float"``).
     """
     return {
         "_schema_version": "1.0",
+        "profiles": [_serialize_profile(p) for p in model.profiles],
         "elements": [_serialize_concept(e) for e in model.elements],
         "relationships": [_serialize_concept(r) for r in model.relationships],
     }
@@ -72,6 +131,10 @@ def model_from_dict(data: dict[str, Any]) -> Model:
     """
     model = Model()
     id_map: dict[str, Concept] = {}
+
+    for prof_data in data.get("profiles", []):
+        profile = _deserialize_profile(prof_data)
+        model.apply_profile(profile)
 
     for elem_data in data.get("elements", []):
         elem_data = dict(elem_data)  # copy so we don't mutate the caller's dict

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -18,6 +18,7 @@ except ImportError as exc:
 
 from etcion.metamodel.concepts import Concept, Element, Relationship
 from etcion.metamodel.model import Model
+from etcion.metamodel.profiles import Profile
 from etcion.serialization.registry import (
     ARCHIMATE_NS,
     ARCHIMATE_SCHEMA_LOCATION,
@@ -31,6 +32,20 @@ from etcion.serialization.registry import (
 # Reverse registry: xml_tag -> concrete Concept subclass.
 # Built once at module load from TYPE_REGISTRY.
 _TAG_TO_TYPE: dict[str, type[Concept]] = {desc.xml_tag: cls for cls, desc in TYPE_REGISTRY.items()}
+
+# Python type <-> XSD type mapping for propertyDefinition/@type.
+_PY_TO_XSD_TYPE: dict[str, str] = {
+    "str": "string",
+    "int": "integer",
+    "float": "real",
+    "bool": "boolean",
+}
+_XSD_TO_PY_TYPE: dict[str, type] = {
+    "string": str,
+    "integer": int,
+    "real": float,
+    "boolean": bool,
+}
 
 
 def _to_exchange_id(internal_id: str) -> str:
@@ -53,6 +68,19 @@ def serialize_element(elem: Element) -> etree._Element:
         doc_el = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}documentation")
         doc_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
         doc_el.text = elem.description
+
+    if elem.specialization:
+        el.set("specialization", elem.specialization)
+
+    if elem.extended_attributes:
+        props_container = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}properties")
+        type_name = TYPE_REGISTRY[type(elem)].xml_tag
+        for attr_name, value in elem.extended_attributes.items():
+            prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
+            prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+            val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
+            val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+            val_el.text = str(value)
 
     return el
 
@@ -88,6 +116,19 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
     name_el = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}name")
     name_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
     name_el.text = model_name
+
+    if model.profiles:
+        propdefs = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        for profile in model.profiles:
+            for cls, attrs in profile.attribute_extensions.items():
+                type_name = TYPE_REGISTRY[cls].xml_tag
+                for attr_name, attr_type in attrs.items():
+                    pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
+                    pd.set("identifier", f"propdef-{type_name}-{attr_name}")
+                    pd.set("type", _PY_TO_XSD_TYPE.get(attr_type.__name__, "string"))
+                    pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
+                    pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+                    pd_name.text = attr_name
 
     elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
     for elem in model.elements:
@@ -126,11 +167,18 @@ def _from_exchange_id(exchange_id: str) -> str:
     return exchange_id[3:] if exchange_id.startswith("id-") else exchange_id
 
 
-def _deserialize_element(node: etree._Element) -> Element | None:
+def _deserialize_element(
+    node: etree._Element,
+    propdef_map: dict[str, tuple[str, type]] | None = None,
+) -> Element | None:
     """Deserialize a single ``<element>`` node.
 
     Returns ``None`` and emits a :func:`warnings.warn` when the ArchiMate
     type attribute is not registered in ``_TAG_TO_TYPE``.
+
+    ``propdef_map`` maps a propertyDefinitionRef identifier to a tuple of
+    ``(attr_name, python_type)`` and is used to reconstruct extended
+    attributes.  Pass ``None`` (default) for models without profiles.
     """
     type_attr = node.get(f"{{{XSI_NS}}}type")
     if type_attr not in _TAG_TO_TYPE:
@@ -142,7 +190,24 @@ def _deserialize_element(node: etree._Element) -> Element | None:
     name: str = name_node.text or "" if name_node is not None else ""
     doc_node = node.find(f"{{{ARCHIMATE_NS}}}documentation")
     desc: str | None = doc_node.text if doc_node is not None else None
-    return cls(id=internal_id, name=name, description=desc)  # type: ignore[call-arg, return-value]
+
+    specialization: str | None = node.get("specialization")
+    extended_attributes: dict[str, Any] = {}
+    props_node = node.find(f"{{{ARCHIMATE_NS}}}properties")
+    if props_node is not None and propdef_map:
+        for prop_node in props_node:
+            ref = prop_node.get("propertyDefinitionRef", "")
+            val_node = prop_node.find(f"{{{ARCHIMATE_NS}}}value")
+            if ref in propdef_map and val_node is not None and val_node.text:
+                attr_name, attr_type = propdef_map[ref]
+                extended_attributes[attr_name] = attr_type(val_node.text)
+
+    kwargs: dict[str, Any] = {}
+    if specialization:
+        kwargs["specialization"] = specialization
+    if extended_attributes:
+        kwargs["extended_attributes"] = extended_attributes
+    return cls(id=internal_id, name=name, description=desc, **kwargs)  # type: ignore[call-arg, return-value]
 
 
 def _deserialize_relationship(
@@ -179,29 +244,74 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
     """Deserialize an Exchange Format :class:`lxml.etree._ElementTree` into a
     :class:`~etcion.metamodel.model.Model`.
 
-    Uses a two-phase approach:
+    Uses a four-phase approach:
 
-    1. Parse all ``<element>`` nodes and build an ``id_map`` keyed by the
-       exchange-format identifier (``id-<uuid>``).
-    2. Parse all ``<relationship>`` nodes, resolving ``source``/``target``
-       references against ``id_map``.
+    1. Parse ``<propertyDefinitions>`` to build a ``propdef_map`` and
+       ``attr_extensions`` for profile reconstruction.
+    2. Parse all ``<element>`` nodes into a list (not yet added to the model),
+       collecting specialization names per element type.
+    3. Reconstruct a synthetic ``"Imported"`` profile from the gathered data
+       and apply it to the model.
+    4. Add elements to the model, then parse relationships.
     """
     root = tree.getroot()
     model = Model()
 
-    # Phase 1: elements
+    # Phase 1: parse propertyDefinitions
+    propdef_map: dict[str, tuple[str, type]] = {}
+    attr_extensions: dict[type[Element], dict[str, type]] = {}
+    propdefs_node = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+    if propdefs_node is not None:
+        for pd_node in propdefs_node:
+            pd_id = pd_node.get("identifier", "")
+            pd_type_str = pd_node.get("type", "string")
+            py_type: type = _XSD_TO_PY_TYPE.get(pd_type_str, str)
+            pd_name_node = pd_node.find(f"{{{ARCHIMATE_NS}}}name")
+            attr_name = pd_name_node.text if pd_name_node is not None and pd_name_node.text else ""
+            propdef_map[pd_id] = (attr_name, py_type)
+            # Identifier scheme: "propdef-TypeName-attr_name"
+            parts = pd_id.split("-", 2)
+            if len(parts) == 3 and parts[1] in _TAG_TO_TYPE:
+                raw_cls = _TAG_TO_TYPE[parts[1]]
+                if not (isinstance(raw_cls, type) and issubclass(raw_cls, Element)):
+                    continue
+                elem_cls: type[Element] = raw_cls
+                if elem_cls not in attr_extensions:
+                    attr_extensions[elem_cls] = {}
+                attr_extensions[elem_cls][attr_name] = py_type
+
+    # Phase 2: parse elements (collect, do not add yet); gather specializations
     id_map: dict[str, Concept] = {}
+    parsed_elements: list[Element] = []
+    specializations: dict[type[Element], list[str]] = {}
     elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
     if elements_node is not None:
         for el_node in elements_node:
-            concept = _deserialize_element(el_node)
+            concept = _deserialize_element(el_node, propdef_map if propdef_map else None)
             if concept is not None:
-                # Key by the EXCHANGE FORMAT id (with id- prefix) so that
-                # relationship source/target refs resolve correctly.
                 id_map[el_node.get("identifier", "")] = concept
-                model.add(concept)
+                parsed_elements.append(concept)
+                if concept.specialization:
+                    cls_type = type(concept)
+                    if cls_type not in specializations:
+                        specializations[cls_type] = []
+                    if concept.specialization not in specializations[cls_type]:
+                        specializations[cls_type].append(concept.specialization)
 
-    # Phase 2: relationships
+    # Phase 3: reconstruct and apply synthetic profile (if any profile data exists)
+    if attr_extensions or specializations:
+        profile = Profile(
+            name="Imported",
+            specializations=specializations,
+            attribute_extensions=attr_extensions,
+        )
+        model.apply_profile(profile)
+
+    # Phase 4: add elements to model
+    for elem in parsed_elements:
+        model.add(elem)
+
+    # Phase 5: relationships
     rels_node = root.find(f"{{{ARCHIMATE_NS}}}relationships")
     if rels_node is not None:
         for rel_node in rels_node:
@@ -213,7 +323,8 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
     opaque: list[etree._Element] = []
     for child in root:
         tag_local = etree.QName(child.tag).localname
-        if tag_local not in ("elements", "relationships", "name", "documentation"):
+        _opaque_skip = ("elements", "relationships", "name", "documentation", "propertyDefinitions")
+        if tag_local not in _opaque_skip:
             opaque.append(child)
     model._opaque_xml = opaque  # type: ignore[attr-defined]
 

--- a/test/serialization/test_json.py
+++ b/test/serialization/test_json.py
@@ -128,3 +128,141 @@ class TestEmptyModel:
         data = model_to_dict(m)
         restored = model_from_dict(data)
         assert len(restored.concepts) == 0
+
+
+@pytest.fixture
+def profiled_model() -> Model:
+    from etcion.metamodel.application import ApplicationComponent
+    from etcion.metamodel.profiles import Profile
+
+    profile = Profile(
+        name="Cloud",
+        specializations={ApplicationComponent: ["Microservice", "API Gateway"]},
+        attribute_extensions={ApplicationComponent: {"region": str, "cost": float}},
+    )
+    m = Model()
+    m.apply_profile(profile)
+
+    svc = ApplicationComponent(
+        name="Order Service",
+        specialization="Microservice",
+        extended_attributes={"region": "eu-west-1", "cost": 42.0},
+    )
+    m.add(svc)
+    return m
+
+
+class TestProfileRoundTrip:
+    def test_model_to_dict_has_profiles_key(self, profiled_model):
+        result = model_to_dict(profiled_model)
+        assert "profiles" in result
+
+    def test_profiles_list_length(self, profiled_model):
+        result = model_to_dict(profiled_model)
+        assert len(result["profiles"]) == 1
+
+    def test_profile_name_serialized(self, profiled_model):
+        result = model_to_dict(profiled_model)
+        assert result["profiles"][0]["name"] == "Cloud"
+
+    def test_profile_specializations_use_type_names(self, profiled_model):
+        result = model_to_dict(profiled_model)
+        specs = result["profiles"][0]["specializations"]
+        assert isinstance(specs, dict)
+        assert all(isinstance(k, str) for k in specs)
+        assert "ApplicationComponent" in specs
+        assert specs["ApplicationComponent"] == ["Microservice", "API Gateway"]
+
+    def test_profile_attribute_extensions_use_type_names(self, profiled_model):
+        result = model_to_dict(profiled_model)
+        attrs = result["profiles"][0]["attribute_extensions"]
+        assert isinstance(attrs, dict)
+        assert "ApplicationComponent" in attrs
+        attr_map = attrs["ApplicationComponent"]
+        assert attr_map["region"] == "str"
+        assert attr_map["cost"] == "float"
+
+    def test_round_trip_profiles_restored(self, profiled_model):
+        data = model_to_dict(profiled_model)
+        restored = model_from_dict(data)
+        assert len(restored.profiles) == 1
+
+    def test_round_trip_profile_name(self, profiled_model):
+        data = model_to_dict(profiled_model)
+        restored = model_from_dict(data)
+        assert restored.profiles[0].name == "Cloud"
+
+    def test_round_trip_specialization_survives(self, profiled_model):
+        data = model_to_dict(profiled_model)
+        restored = model_from_dict(data)
+        elem = restored.elements[0]
+        assert elem.specialization == "Microservice"
+
+    def test_round_trip_extended_attributes_survive(self, profiled_model):
+        data = model_to_dict(profiled_model)
+        restored = model_from_dict(data)
+        elem = restored.elements[0]
+        assert elem.extended_attributes == {"region": "eu-west-1", "cost": 42.0}
+
+    def test_round_trip_validate_passes(self, profiled_model):
+        data = model_to_dict(profiled_model)
+        restored = model_from_dict(data)
+        errors = restored.validate()
+        assert errors == []
+
+    def test_no_profiles_backward_compatible(self):
+        restored = model_from_dict({"elements": [], "relationships": []})
+        assert len(restored.profiles) == 0
+
+
+class TestProfileRoundTripIntegrity:
+    """Issue #50 — comprehensive round-trip integrity for JSON profile serialization."""
+
+    def test_dict_idempotency(self, profiled_model):
+        """model_to_dict → model_from_dict → model_to_dict produces identical dicts."""
+        d1 = model_to_dict(profiled_model)
+        restored = model_from_dict(d1)
+        d2 = model_to_dict(restored)
+        assert d1 == d2
+
+    def test_empty_extended_attributes_no_noise(self):
+        """Elements without extended_attributes should have empty dict, not missing key."""
+        actor = BusinessActor(name="Plain")
+        m = Model()
+        m.add(actor)
+        data = model_to_dict(m)
+        elem_dict = data["elements"][0]
+        # extended_attributes is {} from model_dump — this is fine
+        assert elem_dict.get("extended_attributes") == {}
+        assert elem_dict.get("specialization") is None
+        # Round-trip preserves this
+        restored = model_from_dict(data)
+        assert restored.elements[0].extended_attributes == {}
+        assert restored.elements[0].specialization is None
+
+    def test_specializations_only_profile_round_trip(self):
+        """Profile with specializations but no attribute_extensions round-trips."""
+        from etcion.metamodel.application import ApplicationComponent
+        from etcion.metamodel.profiles import Profile
+
+        profile = Profile(
+            name="Roles",
+            specializations={ApplicationComponent: ["Frontend", "Backend"]},
+        )
+        m = Model()
+        m.apply_profile(profile)
+        svc = ApplicationComponent(name="Web App", specialization="Frontend")
+        m.add(svc)
+
+        data = model_to_dict(m)
+        restored = model_from_dict(data)
+        assert len(restored.profiles) == 1
+        assert restored.elements[0].specialization == "Frontend"
+        assert restored.validate() == []
+
+    def test_validate_passes_after_round_trip(self, profiled_model):
+        """model.validate() returns no errors after JSON round-trip."""
+        data = model_to_dict(profiled_model)
+        restored = model_from_dict(data)
+        assert restored.validate() == []
+        assert len(restored.profiles) > 0

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -28,6 +28,7 @@ from etcion.metamodel.motivation import (  # noqa: E402
     Goal,  # noqa: E402
     Stakeholder,
 )
+from etcion.metamodel.profiles import Profile  # noqa: E402
 from etcion.metamodel.relationships import (  # noqa: E402
     Access,
     Association,
@@ -607,3 +608,258 @@ class TestWriteModel_2:
         name_node = root.find(f"{{{ARCHIMATE_NS}}}name")
         assert name_node is not None
         assert name_node.text == "My Model"
+
+
+# ---------------------------------------------------------------------------
+# Issue #49: Profile and extended attribute XML serialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def profiled_model() -> Model:
+    profile = Profile(
+        name="Cloud",
+        specializations={ApplicationComponent: ["Microservice", "API Gateway"]},
+        attribute_extensions={ApplicationComponent: {"region": str, "cost": float}},
+    )
+    m = Model()
+    m.apply_profile(profile)
+    svc = ApplicationComponent(
+        name="Order Service",
+        specialization="Microservice",
+        extended_attributes={"region": "eu-west-1", "cost": 42.0},
+    )
+    gw = ApplicationComponent(
+        name="Gateway",
+        specialization="API Gateway",
+        extended_attributes={"region": "us-east-1", "cost": 10.5},
+    )
+    m.add(svc)
+    m.add(gw)
+    return m
+
+
+class TestProfileXmlSerialization:
+    """Issue #49 — serialize profiles and extended attributes into XML."""
+
+    def _root(self, profiled_model: Model) -> etree._Element:
+        return serialize_model(profiled_model).getroot()
+
+    def test_serialize_model_has_property_definitions(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        node = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert node is not None
+
+    def test_property_definition_count(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd_container is not None
+        assert len(pd_container) == 2  # region + cost
+
+    def test_property_definition_has_identifier(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd_container is not None
+        identifiers = {pd.get("identifier") for pd in pd_container}
+        assert "propdef-ApplicationComponent-region" in identifiers
+        assert "propdef-ApplicationComponent-cost" in identifiers
+
+    def test_property_definition_has_name(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd_container is not None
+        name_texts = set()
+        for pd in pd_container:
+            name_node = pd.find(f"{{{ARCHIMATE_NS}}}name")
+            assert name_node is not None
+            name_texts.add(name_node.text)
+        assert "region" in name_texts
+        assert "cost" in name_texts
+
+    def test_property_definition_has_type(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd_container is not None
+        type_by_id: dict[str, str] = {}
+        for pd in pd_container:
+            pd_id = pd.get("identifier", "")
+            type_by_id[pd_id] = pd.get("type", "")
+        assert type_by_id["propdef-ApplicationComponent-region"] == "string"
+        assert type_by_id["propdef-ApplicationComponent-cost"] == "real"
+
+    def test_element_has_specialization_attr(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elements_node is not None
+        specializations = [el.get("specialization") for el in elements_node]
+        assert "Microservice" in specializations
+
+    def test_element_has_properties(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elements_node is not None
+        for el in elements_node:
+            props = el.find(f"{{{ARCHIMATE_NS}}}properties")
+            assert props is not None, f"<properties> missing on element {el.get('identifier')}"
+
+    def test_element_property_count(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elements_node is not None
+        for el in elements_node:
+            props = el.find(f"{{{ARCHIMATE_NS}}}properties")
+            assert props is not None
+            assert len(props) == 2, f"Expected 2 properties, got {len(props)}"
+
+    def test_element_property_has_value(self, profiled_model: Model) -> None:
+        root = self._root(profiled_model)
+        elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elements_node is not None
+        for el in elements_node:
+            props = el.find(f"{{{ARCHIMATE_NS}}}properties")
+            assert props is not None
+            for prop in props:
+                val_node = prop.find(f"{{{ARCHIMATE_NS}}}value")
+                assert val_node is not None
+                assert val_node.text is not None and val_node.text != ""
+
+    def test_element_no_specialization_when_none(self, simple_model: Model) -> None:
+        # simple_model has no profiles; elements must not carry specialization attr
+        root = serialize_model(simple_model).getroot()
+        elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elements_node is not None
+        for el in elements_node:
+            assert el.get("specialization") is None
+
+
+class TestProfileXmlRoundTrip:
+    """Issue #49 — round-trip fidelity for profiles, specializations, and extended attrs."""
+
+    def _round_trip(self, model: Model) -> Model:
+        tree = serialize_model(model)
+        return deserialize_model(tree)
+
+    def test_round_trip_specialization_preserved(self, profiled_model: Model) -> None:
+        restored = self._round_trip(profiled_model)
+        specializations = {e.specialization for e in restored.elements}
+        assert "Microservice" in specializations
+
+    def test_round_trip_extended_attributes_preserved(self, profiled_model: Model) -> None:
+        restored = self._round_trip(profiled_model)
+        svc = next(e for e in restored.elements if e.name == "Order Service")
+        assert svc.extended_attributes == {"region": "eu-west-1", "cost": 42.0}
+
+    def test_round_trip_profile_reconstructed(self, profiled_model: Model) -> None:
+        restored = self._round_trip(profiled_model)
+        assert len(restored.profiles) == 1
+
+    def test_round_trip_validate_passes(self, profiled_model: Model) -> None:
+        restored = self._round_trip(profiled_model)
+        errors = restored.validate()
+        assert errors == []
+
+    def test_no_profile_backward_compatible(self, simple_model: Model) -> None:
+        restored = self._round_trip(simple_model)
+        # No profiles, no errors
+        assert restored.profiles == []
+        assert len(restored.elements) == len(simple_model.elements)
+
+
+class TestProfileXmlRoundTripIntegrity:
+    """Issue #50 — comprehensive round-trip integrity for XML profile serialization."""
+
+    def _round_trip(self, model: Model) -> Model:
+        tree = serialize_model(model)
+        return deserialize_model(tree)
+
+    def test_xml_idempotency_element_data(self, profiled_model: Model) -> None:
+        """serialize → deserialize → serialize produces identical element data."""
+        tree1 = serialize_model(profiled_model)
+        restored = deserialize_model(tree1)
+        tree2 = serialize_model(restored)
+
+        root1 = tree1.getroot()
+        root2 = tree2.getroot()
+
+        # Compare elements
+        elems1 = root1.find(f"{{{ARCHIMATE_NS}}}elements")
+        elems2 = root2.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elems1 is not None and elems2 is not None
+        assert len(elems1) == len(elems2)
+
+        # Compare by name: each element should have same type, specialization, and properties
+        def _elem_key(el):
+            name_node = el.find(f"{{{ARCHIMATE_NS}}}name")
+            return name_node.text if name_node is not None else ""
+
+        for e1, e2 in zip(
+            sorted(elems1, key=_elem_key),
+            sorted(elems2, key=_elem_key),
+            strict=True,
+        ):
+            assert e1.get(f"{{{XSI_NS}}}type") == e2.get(f"{{{XSI_NS}}}type")
+            assert e1.get("specialization") == e2.get("specialization")
+            # Compare property values
+            props1 = e1.find(f"{{{ARCHIMATE_NS}}}properties")
+            props2 = e2.find(f"{{{ARCHIMATE_NS}}}properties")
+            if props1 is not None:
+                assert props2 is not None
+                assert len(props1) == len(props2)
+
+    def test_xml_idempotency_property_definitions(self, profiled_model: Model) -> None:
+        """propertyDefinitions survive round-trip."""
+        tree1 = serialize_model(profiled_model)
+        restored = deserialize_model(tree1)
+        tree2 = serialize_model(restored)
+
+        root1 = tree1.getroot()
+        root2 = tree2.getroot()
+
+        pd1 = root1.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        pd2 = root2.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd1 is not None and pd2 is not None
+        assert len(pd1) == len(pd2)
+
+    def test_empty_extended_attributes_no_properties_element(self) -> None:
+        """Elements without extended_attributes must NOT emit <properties>."""
+        actor = BusinessActor(name="Plain")
+        m = Model()
+        m.add(actor)
+        tree = serialize_model(m)
+        root = tree.getroot()
+        elems = root.find(f"{{{ARCHIMATE_NS}}}elements")
+        assert elems is not None
+        for el in elems:
+            props = el.find(f"{{{ARCHIMATE_NS}}}properties")
+            assert props is None, "Empty extended_attributes should not produce <properties>"
+
+    def test_no_property_definitions_without_profiles(self) -> None:
+        """Model without profiles should not emit <propertyDefinitions>."""
+        m = Model()
+        m.add(BusinessActor(name="A"))
+        tree = serialize_model(m)
+        root = tree.getroot()
+        pd = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd is None
+
+    def test_specializations_only_profile_round_trip(self) -> None:
+        """Profile with specializations but no attribute_extensions round-trips."""
+        profile = Profile(
+            name="Roles",
+            specializations={ApplicationComponent: ["Frontend", "Backend"]},
+        )
+        m = Model()
+        m.apply_profile(profile)
+        svc = ApplicationComponent(name="Web App", specialization="Frontend")
+        m.add(svc)
+
+        restored = self._round_trip(m)
+        assert len(restored.profiles) == 1
+        elem = next(e for e in restored.elements if e.name == "Web App")
+        assert elem.specialization == "Frontend"
+        assert restored.validate() == []
+
+    def test_validate_passes_after_round_trip(self, profiled_model: Model) -> None:
+        restored = self._round_trip(profiled_model)
+        assert restored.validate() == []
+        assert len(restored.profiles) > 0

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -19,7 +19,7 @@ class TestVersionExposed:
     """etcion.__version__ is publicly accessible and correct."""
 
     def test_version_exposed(self) -> None:
-        assert etcion.__version__ == "0.4.1"
+        assert etcion.__version__ == "0.5.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(etcion.__version__, str)

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -69,7 +69,7 @@ class TestProjectMetadata:
 
     def test_project_version(self) -> None:
         data = _load_toml()
-        assert data["project"]["version"] == "0.4.1"
+        assert data["project"]["version"] == "0.5.0"
 
     def test_requires_python(self) -> None:
         data = _load_toml()


### PR DESCRIPTION
## Summary

- JSON: model_to_dict/model_from_dict now serialize/deserialize Profile objects
- XML: serialize_model emits <propertyDefinitions>; serialize_element emits specialization attr + <properties>
- Round-trip integrity tests for both formats

Closes #48, closes #49, closes #50, closes #54