### PR TITLE
Hotfix v0.5.1: XML Exchange Format compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 01 Apr 2026
+
+### Fixed
+
+- **XML property type mapping** -- replaced invalid XSD type values `"real"` and
+  `"integer"` with `"number"` per the ArchiMate Exchange Format enumeration
+  (`string`, `boolean`, `currency`, `date`, `time`, `number`).
+- **XML element ordering** -- moved `<propertyDefinitions>` after `<elements>`,
+  `<relationships>`, and `<organizations>` to match the `ModelType` sequence
+  required by the XSD.
+- **XML specialization encoding** -- serialized `specialization` as a
+  `<property>` referencing a well-known `propdef-specialization` property
+  definition instead of an invalid XML attribute on `<element>`.
+- **XML dangling property refs** -- `serialize_model()` now emits
+  `<propertyDefinition>` entries for all extended attributes used by elements,
+  not just those declared in profile `attribute_extensions`.
+- **Petco example** -- changed ApplicationComponent → ApplicationInterface
+  relationship from `Assignment` to `Composition` per ArchiMate spec.
+
 ## [0.5.0] - 01 Apr 2026
 
 ### Added

--- a/docs/examples/petco/build_model.py
+++ b/docs/examples/petco/build_model.py
@@ -319,7 +319,7 @@ def _build_integrations(
             },
         )
         model.add(iface)
-        model.add(Assignment(name="", source=source_app, target=iface))
+        model.add(Composition(name="", source=source_app, target=iface))
 
 
 def _build_technology(

--- a/docs/examples/petco/petco.xml
+++ b/docs/examples/petco/petco.xml
@@ -1,14 +1,2837 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="id-model-root" xsi:schemaLocation="http://www.opengroup.org/xsd/archimate/3.0/ http://www.opengroup.org/xsd/archimate/3.1/archimate3_Diagram.xsd">
   <name xml:lang="en">petco.xml</name>
+  <elements>
+    <element identifier="id-34722c2c-022c-45bb-942e-cc8a38a875eb" xsi:type="Capability">
+      <name xml:lang="en">Customer Management</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">established</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">invest</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-84b25d10-7046-496e-bf37-ce329675ec09" xsi:type="Capability">
+      <name xml:lang="en">Customer Onboarding</name>
+    </element>
+    <element identifier="id-c8d7dac0-c947-4394-ab5e-9c39f6de9f11" xsi:type="Capability">
+      <name xml:lang="en">Customer Identity &amp; Profile</name>
+    </element>
+    <element identifier="id-643f89dd-aaf9-41ed-8721-6b254ee1e2a3" xsi:type="Capability">
+      <name xml:lang="en">Loyalty &amp; Rewards</name>
+    </element>
+    <element identifier="id-c3aa4fe1-a75b-4fcf-8e13-6c32f8e2e3c2" xsi:type="Capability">
+      <name xml:lang="en">Customer Communication</name>
+    </element>
+    <element identifier="id-8b9bdb80-e905-4970-8b03-0c7c7cb36fc5" xsi:type="Capability">
+      <name xml:lang="en">Commerce</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">established</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">invest</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-321c2bb7-845e-400f-8746-7888dcfe5767" xsi:type="Capability">
+      <name xml:lang="en">Online Ordering</name>
+    </element>
+    <element identifier="id-76ad5841-1daf-495b-8979-875d1e10626e" xsi:type="Capability">
+      <name xml:lang="en">In-Store Point of Sale</name>
+    </element>
+    <element identifier="id-b7bd6b3f-b0a3-43ce-a960-505ada4294bf" xsi:type="Capability">
+      <name xml:lang="en">Marketplace Management</name>
+    </element>
+    <element identifier="id-280b7a03-f70d-46e2-bb75-c2fd315ca475" xsi:type="Capability">
+      <name xml:lang="en">Pricing &amp; Promotions</name>
+    </element>
+    <element identifier="id-b53d6f34-18f4-4383-aaaf-489dfe5c9ebb" xsi:type="Capability">
+      <name xml:lang="en">Cart &amp; Checkout</name>
+    </element>
+    <element identifier="id-647e2ff6-4bbd-4c58-aaab-753262a00ff8" xsi:type="Capability">
+      <name xml:lang="en">Product Management</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">established</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">maintain</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3d7e06f8-1b75-42ce-b17a-a4e5eb753f82" xsi:type="Capability">
+      <name xml:lang="en">Product Catalog</name>
+    </element>
+    <element identifier="id-a8a020a1-771a-49f6-a65f-8a4043c85191" xsi:type="Capability">
+      <name xml:lang="en">Product Sourcing</name>
+    </element>
+    <element identifier="id-6fe82059-a0a4-46bc-b394-0cbf02300a8b" xsi:type="Capability">
+      <name xml:lang="en">Vendor Management</name>
+    </element>
+    <element identifier="id-b5704b9d-dc39-4f89-8a1b-cb737c8bcd7a" xsi:type="Capability">
+      <name xml:lang="en">Inventory &amp; Fulfillment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">emerging</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">invest</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-a4cd67ce-bdef-4f2e-ac75-bdcee15c79b2" xsi:type="Capability">
+      <name xml:lang="en">Inventory Management</name>
+    </element>
+    <element identifier="id-1310a45e-7787-4f98-80fd-260db0651f40" xsi:type="Capability">
+      <name xml:lang="en">Warehouse Operations</name>
+    </element>
+    <element identifier="id-861aa878-8acb-435e-829f-b186c8d084e2" xsi:type="Capability">
+      <name xml:lang="en">Order Fulfillment</name>
+    </element>
+    <element identifier="id-aaa8fe45-2a6c-4d33-96bc-8b8a266b8a42" xsi:type="Capability">
+      <name xml:lang="en">Ship-from-Store</name>
+    </element>
+    <element identifier="id-5aa6e0bb-2322-4df5-bfde-c2807ea4dced" xsi:type="Capability">
+      <name xml:lang="en">Returns Processing</name>
+    </element>
+    <element identifier="id-45212a57-3df1-4d40-9a7a-e0a2078681e7" xsi:type="Capability">
+      <name xml:lang="en">Payment Processing</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">established</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">maintain</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-de5a5fce-5933-4ffe-b3cc-ac2697074367" xsi:type="Capability">
+      <name xml:lang="en">Payment Authorization</name>
+    </element>
+    <element identifier="id-41b3a772-0cbb-4af4-870e-e68e07c9fd36" xsi:type="Capability">
+      <name xml:lang="en">Payment Settlement</name>
+    </element>
+    <element identifier="id-4e6ae9ea-e7a0-472e-9dd9-673d7bed3021" xsi:type="Capability">
+      <name xml:lang="en">Refund Processing</name>
+    </element>
+    <element identifier="id-4dc6bff3-bc09-416e-b9cc-02da79bc38c3" xsi:type="Capability">
+      <name xml:lang="en">Supply Chain</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">established</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">maintain</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-900218f9-f570-4592-ba44-8e42c42ce71c" xsi:type="Capability">
+      <name xml:lang="en">Demand Forecasting</name>
+    </element>
+    <element identifier="id-06cb31a2-5b2f-4d77-8609-5431ab325b2e" xsi:type="Capability">
+      <name xml:lang="en">Purchase Order Management</name>
+    </element>
+    <element identifier="id-85fd9ec2-262c-447a-b84d-d9147331f2a3" xsi:type="Capability">
+      <name xml:lang="en">Supplier Logistics</name>
+    </element>
+    <element identifier="id-938a7882-81b5-43a4-af92-27b1f21f5f42" xsi:type="Capability">
+      <name xml:lang="en">Veterinary Services</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">emerging</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">invest</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-628934c1-822b-4fb1-99ce-d96d693c1001" xsi:type="Capability">
+      <name xml:lang="en">Clinic Appointment Scheduling</name>
+    </element>
+    <element identifier="id-144639a3-e342-403f-976e-018d7e88a901" xsi:type="Capability">
+      <name xml:lang="en">Pet Health Records</name>
+    </element>
+    <element identifier="id-484ecf36-d0a6-4b6f-baee-24d0fa5ec337" xsi:type="Capability">
+      <name xml:lang="en">Prescription Management</name>
+    </element>
+    <element identifier="id-5a27e344-7512-4d16-b67b-10533fc12c29" xsi:type="Capability">
+      <name xml:lang="en">Subscription &amp; Wellness</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">emerging</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">invest</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-83ff968c-9fd1-4102-84df-c24fd8cb28da" xsi:type="Capability">
+      <name xml:lang="en">Subscription Lifecycle</name>
+    </element>
+    <element identifier="id-f36f5ac1-27c0-4da3-9832-f869185502e7" xsi:type="Capability">
+      <name xml:lang="en">Autoship Management</name>
+    </element>
+    <element identifier="id-9ef508bf-e5fc-44a8-adbb-59b826cb7523" xsi:type="Capability">
+      <name xml:lang="en">Wellness Plan Administration</name>
+    </element>
+    <element identifier="id-8d1f9bee-4961-4ac0-9b2a-b1ca8d0d23d2" xsi:type="Capability">
+      <name xml:lang="en">Corporate Operations</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">established</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">maintain</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5355a765-8ae6-4aff-92c7-1fc889a21874" xsi:type="Capability">
+      <name xml:lang="en">Financial Management</name>
+    </element>
+    <element identifier="id-04d676e8-c319-47a8-9af1-41b6ff63a645" xsi:type="Capability">
+      <name xml:lang="en">Human Resources</name>
+    </element>
+    <element identifier="id-759f84bd-36a1-416a-bd39-c4ca3fc96730" xsi:type="Capability">
+      <name xml:lang="en">Store Operations</name>
+    </element>
+    <element identifier="id-7f436d2a-62f5-40f3-9740-8f30ce1f3ee5" xsi:type="Capability">
+      <name xml:lang="en">Analytics &amp; Insights</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-Capability-maturity">
+          <value xml:lang="en">emerging</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
+          <value xml:lang="en">invest</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-55eaf96b-a07e-4d60-ad86-6d568e39fbf3" xsi:type="Capability">
+      <name xml:lang="en">Business Intelligence</name>
+    </element>
+    <element identifier="id-09566991-6f25-4d6d-9f1c-8af118f70ac9" xsi:type="Capability">
+      <name xml:lang="en">Customer Analytics</name>
+    </element>
+    <element identifier="id-e88fb54e-74e1-4c32-b324-c94cfedd9d1f" xsi:type="Capability">
+      <name xml:lang="en">Demand Analytics</name>
+    </element>
+    <element identifier="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" xsi:type="ApplicationComponent">
+      <name xml:lang="en">PawsPlus.com</name>
+      <documentation xml:lang="en">E-commerce web and mobile platform</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.3</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">1800000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e56a1711-cd55-483f-8c46-f52c420e0476" xsi:type="ApplicationComponent">
+      <name xml:lang="en">StoreOS POS</name>
+      <documentation xml:lang="en">In-store point of sale terminals and kiosks</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.8</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">950000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Store Technology</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Loyalty Engine</name>
+      <documentation xml:lang="en">Points, tiers, and rewards management</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">320000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Customer Experience</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-1dea16af-8743-455c-a0d2-940006778981" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Promo Manager</name>
+      <documentation xml:lang="en">Pricing rules, promotions, and coupon management</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.5</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">280000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Merchandising Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Customer Hub</name>
+      <documentation xml:lang="en">Customer identity, profile, and preferences (CDP)</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.5</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">650000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Customer Experience</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-306f394a-2e02-4fd3-bb7e-8475e756652c" xsi:type="ApplicationComponent">
+      <name xml:lang="en">CommsPlatform</name>
+      <documentation xml:lang="en">Email, SMS, push notification orchestration</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">420000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Customer Experience</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-9f312eed-cd28-4dce-965f-9549b0b22b72" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Product Information Manager</name>
+      <documentation xml:lang="en">Product catalog, attributes, images, and taxonomy</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">380000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Merchandising Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5a359712-886b-410c-a811-6a37d9728fad" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Vendor Portal</name>
+      <documentation xml:lang="en">Supplier onboarding, compliance, and communication</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">190000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Supply Chain Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Inventory Service</name>
+      <documentation xml:lang="en">Real-time inventory positions across all channels</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.4</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">720000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Warehouse Management System</name>
+      <documentation xml:lang="en">DC operations, pick/pack/ship</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.6</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">1100000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Order Management System</name>
+      <documentation xml:lang="en">Order lifecycle, routing, and orchestration</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">890000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3342d891-a82d-490a-846d-00b5a0074c1c" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Legacy Returns Processor</name>
+      <documentation xml:lang="en">Returns authorization and restocking (mainframe-based)</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">sunset</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">1.8</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">450000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-9c6344bc-55b8-48d3-8740-543c4f22b773" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Payment Gateway</name>
+      <documentation xml:lang="en">Card authorization, tokenization, and fraud screening</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.6</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">580000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Payments</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Settlement Engine</name>
+      <documentation xml:lang="en">End-of-day batch settlement and reconciliation</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.4</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">310000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Payments</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d2228401-402d-4814-a860-9d9f3f762460" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Demand Planner</name>
+      <documentation xml:lang="en">ML-based demand forecasting and replenishment</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.9</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">480000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Supply Chain Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-38608a00-6935-4cbb-b182-3e345311d32e" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Supplier Logistics Hub</name>
+      <documentation xml:lang="en">Inbound logistics, ASN tracking, dock scheduling</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">260000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Supply Chain Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" xsi:type="ApplicationComponent">
+      <name xml:lang="en">VetConnect</name>
+      <documentation xml:lang="en">Clinic scheduling, partner integration, telehealth</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.7</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">520000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Vet Services Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" xsi:type="ApplicationComponent">
+      <name xml:lang="en">RxManager</name>
+      <documentation xml:lang="en">Pet prescription management and pharmacy integration</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.3</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">340000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Vet Services Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" xsi:type="ApplicationComponent">
+      <name xml:lang="en">PawsCare+ Platform</name>
+      <documentation xml:lang="en">Subscription management, autoship, wellness plans</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">680000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Subscription Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-616f25a9-5656-47dd-a0a4-e69c0532b230" xsi:type="ApplicationComponent">
+      <name xml:lang="en">SAP ERP</name>
+      <documentation xml:lang="en">Finance, GL, AP/AR, fixed assets</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">2200000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Enterprise Systems</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-cd6afa27-4621-405a-882a-1b059cab5b30" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Workday HCM</name>
+      <documentation xml:lang="en">HR, payroll, talent management</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">890000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Enterprise Systems</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-dfd92e6a-82cc-4340-a5a6-3f07c9b96acf" xsi:type="ApplicationComponent">
+      <name xml:lang="en">StoreOps Dashboard</name>
+      <documentation xml:lang="en">Store performance, staffing, and task management</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">3.5</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">210000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Store Technology</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Enterprise Data Warehouse</name>
+      <documentation xml:lang="en">Snowflake-based analytical data store</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.3</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">960000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Data Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-ddd07811-d0ae-4faa-b803-1f8c49e53fa1" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Analytics Portal</name>
+      <documentation xml:lang="en">Tableau-based dashboards and self-service analytics</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">active</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">4.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">350000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Data Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d7defcd1-0807-4544-9b70-1343cd2f42fa" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Legacy Reporting DB</name>
+      <documentation xml:lang="en">Oracle-based reporting database (being migrated to EDW)</documentation>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
+          <value xml:lang="en">sunset</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
+          <value xml:lang="en">2.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
+          <value xml:lang="en">380000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
+          <value xml:lang="en">Data Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3b586ae3-8f43-4766-b3ff-131a57d3f66b" xsi:type="ApplicationService">
+      <name xml:lang="en">Submit Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d92cdc26-7b92-428f-b49d-86dab9ecfde2" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v2/orders</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">35000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">500.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-f7c3a569-3239-4622-988e-5056a5424ddd" xsi:type="ApplicationService">
+      <name xml:lang="en">Customer Lookup</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-4c8b46d5-8bfa-494e-beba-43f495203e95" xsi:type="ApplicationInterface">
+      <name xml:lang="en">GET /v1/customers/{id}</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">280000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">100.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-6660f496-212d-4d43-a5e3-33a1aabd94b1" xsi:type="ApplicationService">
+      <name xml:lang="en">Product Search</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-46ac206c-a820-4e67-80f1-360adce42e10" xsi:type="ApplicationInterface">
+      <name xml:lang="en">GET /v2/products/search</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">1200000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">150.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-8caa491c-7166-4831-a3e7-17e8b383b2f9" xsi:type="ApplicationService">
+      <name xml:lang="en">Check Availability</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-8b33a653-43af-46bb-a442-915e399aefb0" xsi:type="ApplicationInterface">
+      <name xml:lang="en">GET /v1/inventory/availability</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">950000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">200.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-46b732ca-7dc0-461a-a80d-094d0956a6a4" xsi:type="ApplicationService">
+      <name xml:lang="en">Process Payment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3cef0cab-3dd6-45e3-83ed-202a633c3270" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v2/charges</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">35000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-05826787-3bf2-4310-8b54-13e3327c7c04" xsi:type="ApplicationService">
+      <name xml:lang="en">Apply Rewards</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3796b2a7-8475-48de-bd42-da09dadea6af" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/rewards/apply</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">22000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">200.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-58252994-6799-4172-b41c-7b0bc3618f4e" xsi:type="ApplicationService">
+      <name xml:lang="en">Evaluate Promotions</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Digital Commerce</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-104010de-beeb-4697-8422-0ddb3c682bb7" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/promotions/evaluate</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">450000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">100.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-a5f6f044-a46a-4538-bb93-3a2ee21fb744" xsi:type="ApplicationService">
+      <name xml:lang="en">Process Payment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Store Technology</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-12a212d2-51f4-41c1-8ec5-eca24044863b" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v2/charges</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">120000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5b56ddc9-0551-4618-9340-8d0cf8b56a42" xsi:type="ApplicationService">
+      <name xml:lang="en">Reserve Inventory</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Store Technology</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e828f946-5f7f-4070-b182-bce94422bc7b" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/inventory/reserve</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">120000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">200.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-44984b3f-3902-4f80-9c70-dd38e9a8e8de" xsi:type="ApplicationService">
+      <name xml:lang="en">Redeem Points</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Store Technology</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-f6b51463-186c-45e8-bca1-342f5fcb0831" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/rewards/redeem</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">45000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">200.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7b6b9bf5-273d-4dc5-b179-b0783c185a83" xsi:type="ApplicationService">
+      <name xml:lang="en">Allocate Inventory</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-6312b769-1930-486d-b0b8-0511865f84b5" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/inventory/allocate</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">40000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d38f73b7-569d-411d-bfa0-ca31fd62f75a" xsi:type="ApplicationService">
+      <name xml:lang="en">Create Shipment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-ef756bf4-b051-478c-8446-b5231f6e0dee" xsi:type="ApplicationInterface">
+      <name xml:lang="en">orders.routed (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">38000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">5000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-670037f8-e7de-46b5-be8a-10bf505c9b80" xsi:type="ApplicationService">
+      <name xml:lang="en">Order Notification</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7b966d33-573f-4b2f-a123-d6c712edad31" xsi:type="ApplicationInterface">
+      <name xml:lang="en">notifications.order (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">40000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">30000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d085d7d6-8935-424f-9912-a2f920d37fa1" xsi:type="ApplicationService">
+      <name xml:lang="en">Authorize Return</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-b439cc07-44c6-4ba8-98bb-ce33cfbd7f62" xsi:type="ApplicationInterface">
+      <name xml:lang="en">RETURNS.AUTH.REQ (MQ)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">MQ</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">MQ</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">3500.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">10000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-9e7c5c6b-7930-444c-ac37-3d0f54043475" xsi:type="ApplicationService">
+      <name xml:lang="en">Settlement Batch</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Payments</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-9849fe68-1419-4511-a5bf-a10e8f89a7fd" xsi:type="ApplicationInterface">
+      <name xml:lang="en">payments.authorized (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">155000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">60000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-52ad528d-5159-463d-9cd5-8543c381492a" xsi:type="ApplicationService">
+      <name xml:lang="en">Post Journal Entry</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Payments</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-08f482ea-2b3e-438e-aa3e-d3c306e4e1c2" xsi:type="ApplicationInterface">
+      <name xml:lang="en">SETTLEMENT.SFTP</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">SFTP</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">SFTP</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">1.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">3600000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5c30ad43-e46d-4ced-8eca-64c40fca888b" xsi:type="ApplicationService">
+      <name xml:lang="en">Inventory Snapshot</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7405dc79-410b-40eb-874d-29a8851c3f53" xsi:type="ApplicationInterface">
+      <name xml:lang="en">inventory.snapshot (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">150.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">60000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-06b220fe-1d24-46ff-a689-2faa8df89d74" xsi:type="ApplicationService">
+      <name xml:lang="en">Stock Update</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-244ab6dc-71ee-4484-97f1-0e384d1bda51" xsi:type="ApplicationInterface">
+      <name xml:lang="en">inventory.adjustments (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">85000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">5000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-bb4472ba-07e1-41ce-b033-1ae83cf47216" xsi:type="ApplicationService">
+      <name xml:lang="en">Create Purchase Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Supply Chain Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-4291a914-8df2-4ad8-9c0e-e096a54e3c17" xsi:type="ApplicationInterface">
+      <name xml:lang="en">RFC/BAPI MM.PO.CREATE</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">SOAP</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">SOAP</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">200.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">5000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3d464bc5-d993-4c02-a102-fba7c9e74d63" xsi:type="ApplicationService">
+      <name xml:lang="en">ASN Notification</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Supply Chain Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-c7ea0074-18d8-40d6-aec5-f87f0a6cf7e2" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/asn</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">500.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">2000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-4f1b0e08-15c9-4468-84fe-65c6e4e03e1b" xsi:type="ApplicationService">
+      <name xml:lang="en">Inbound Receipt</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Supply Chain Tech</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-c31d186c-7fd4-402d-9d43-537303125ec4" xsi:type="ApplicationInterface">
+      <name xml:lang="en">receiving.inbound (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">500.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">30000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e7c1a5af-2d0f-4ca3-bf31-17d146eff0e9" xsi:type="ApplicationService">
+      <name xml:lang="en">Link Pet to Customer</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Vet Services Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-ca4cdad6-3f2c-40d8-a9b7-bc5ef3be46b9" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/customers/{id}/pets</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">2500.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">500.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-54d82289-dd2c-4322-8a03-bef08ab4cf05" xsi:type="ApplicationService">
+      <name xml:lang="en">Create Prescription</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Vet Services Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5cdaa285-8bef-438d-ac35-1e4f07fd0776" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v1/prescriptions</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">1800.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">500.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7d8eb0f3-1df3-49cc-8846-9735ce26b71e" xsi:type="ApplicationService">
+      <name xml:lang="en">Create Autoship Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Subscription Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5cf60122-c43b-4b47-9bb1-0c6880ef1f1b" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v2/orders</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">12000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">500.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-99721a11-d4ee-40a7-a8e8-fb8542229afa" xsi:type="ApplicationService">
+      <name xml:lang="en">Recurring Charge</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Subscription Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-dc8e7cba-fdaa-41e0-94b7-45f013bc5a89" xsi:type="ApplicationInterface">
+      <name xml:lang="en">POST /v2/charges/recurring</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">REST</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">12000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-1edd1f68-c2d9-47ed-b78e-7e48554ad4f1" xsi:type="ApplicationService">
+      <name xml:lang="en">Subscription Notification</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Subscription Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-c13be14f-b294-43ed-b05e-ec441198058f" xsi:type="ApplicationInterface">
+      <name xml:lang="en">notifications.subscription (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">15000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">30000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-8c9e2f9c-0ab8-4e56-b5d2-b37fd16ee4b4" xsi:type="ApplicationService">
+      <name xml:lang="en">Prescription Ready Notification</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Vet Services Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-9628c856-2c41-4b45-bc51-359af00b6f74" xsi:type="ApplicationInterface">
+      <name xml:lang="en">notifications.rx (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">1800.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">30000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d35e68eb-0ab9-4217-9d65-8798dbcd92d0" xsi:type="ApplicationService">
+      <name xml:lang="en">Order Events Feed</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-618e1e84-bb38-4d14-96eb-195f6ca93479" xsi:type="ApplicationInterface">
+      <name xml:lang="en">orders.completed (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">35000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e7f2a495-748a-4013-a86f-575f2d9c993e" xsi:type="ApplicationService">
+      <name xml:lang="en">Customer Profile Sync</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Customer Experience</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-bd2b16fb-71c0-41bf-923a-47fbc5aa08a6" xsi:type="ApplicationInterface">
+      <name xml:lang="en">customers.updated (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">50000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-b0efa90b-92c0-4438-bd5a-d39830fb85b4" xsi:type="ApplicationService">
+      <name xml:lang="en">Inventory Events Feed</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier3</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Fulfillment Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-1b6d8cd3-5f8b-425b-b9c5-a5d02452ee0c" xsi:type="ApplicationInterface">
+      <name xml:lang="en">inventory.changes (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">Kafka</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">200000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">300000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-f70216ed-37b1-4adb-b188-7984ba39c4cb" xsi:type="ApplicationService">
+      <name xml:lang="en">Dashboard Queries</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier2</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Data Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-baaf9a2e-52b3-434c-bd1a-d48bb5a5f744" xsi:type="ApplicationInterface">
+      <name xml:lang="en">Snowflake JDBC</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">JDBC</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">JDBC</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">25000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">10000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-b88fe301-4784-4b2e-bcc5-f650510a0fbd" xsi:type="ApplicationService">
+      <name xml:lang="en">Legacy Data Migration</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
+          <value xml:lang="en">tier3</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
+          <value xml:lang="en">Data Engineering</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-86af5225-cfe5-4d85-aa78-f55f4cfdc410" xsi:type="ApplicationInterface">
+      <name xml:lang="en">LEGACY.ETL.SFTP</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">SFTP</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
+          <value xml:lang="en">SFTP</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
+          <value xml:lang="en">1.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
+          <value xml:lang="en">7200000.0</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d713582c-3420-46bc-89e2-50a210639fcf" xsi:type="Node">
+      <name xml:lang="en">commerce-prod-eks</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kubernetes Cluster</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">AWS</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">us-east-1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5870ddac-a467-4383-aae3-73b65edd402e" xsi:type="Node">
+      <name xml:lang="en">services-prod-eks</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kubernetes Cluster</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">AWS</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">us-east-1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-c365642e-6789-4cdf-8525-5bcaee529a0e" xsi:type="Node">
+      <name xml:lang="en">fulfillment-prod-eks</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kubernetes Cluster</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">AWS</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">us-east-1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-14205d21-6763-4964-82f0-788d63fd2c41" xsi:type="Node">
+      <name xml:lang="en">vet-prod-eks</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Kubernetes Cluster</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">AWS</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">us-east-1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-1140ce13-3ccf-4f24-be1e-fc9e794a7985" xsi:type="Node">
+      <name xml:lang="en">pos-store-servers</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">VM</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">on-prem</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">150 store locations</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-551c1ee0-69f1-42a2-b981-a7aff38ba20c" xsi:type="Node">
+      <name xml:lang="en">erp-on-prem-cluster</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">VM</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">on-prem</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">Ashburn DC</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-41c147f3-7d6b-4a09-9356-cb53a2b46fc2" xsi:type="Node">
+      <name xml:lang="en">legacy-mainframe</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">VM</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">on-prem</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">Ashburn DC</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-1f21b9e8-44d4-450d-8c9d-28bec472d4dc" xsi:type="Node">
+      <name xml:lang="en">workday-cloud</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Serverless</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-cloud_provider">
+          <value xml:lang="en">Workday Cloud</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-region">
+          <value xml:lang="en">US</value>
+        </property>
+        <property propertyDefinitionRef="propdef-Node-environment">
+          <value xml:lang="en">production</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7d9353c1-69d8-4674-b80b-8a731fc72e17" xsi:type="SystemSoftware">
+      <name xml:lang="en">Aurora PostgreSQL (Commerce)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Database</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">15.4</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en">2027-11-11</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">0.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-78df0baa-84ff-40d1-9491-a08d5ec6c549" xsi:type="SystemSoftware">
+      <name xml:lang="en">Aurora PostgreSQL (Services)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Database</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">15.4</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en">2027-11-11</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">0.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-f7fc19e3-aae0-42d3-a85c-a84a23d7b15e" xsi:type="SystemSoftware">
+      <name xml:lang="en">MongoDB Atlas</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Database</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">7.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">86000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-d94110fc-ff5c-488d-a115-562b02086a91" xsi:type="SystemSoftware">
+      <name xml:lang="en">Oracle 12c (Legacy)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Database</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">12.2.0.1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en">2022-03-31</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">420000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">retiring</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" xsi:type="SystemSoftware">
+      <name xml:lang="en">Amazon MSK (Kafka)</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Message Broker</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">3.6</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">180000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-f632a587-c412-46bd-a387-17b8494b5700" xsi:type="SystemSoftware">
+      <name xml:lang="en">IBM MQ</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Message Broker</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">9.3</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en">2027-04-30</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">95000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">tolerated</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-8f7bb481-ccad-44be-833d-7a9889174c60" xsi:type="SystemSoftware">
+      <name xml:lang="en">ElastiCache Redis</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Cache</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">7.1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">48000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-121a17d2-ac0c-4a5c-ad84-2549b485258f" xsi:type="SystemSoftware">
+      <name xml:lang="en">OpenSearch</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Search Engine</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">2.11</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">62000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e68a0e41-1593-42a1-9493-fa546f44bf4b" xsi:type="SystemSoftware">
+      <name xml:lang="en">CloudFront CDN</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">CDN</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">96000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-4f439377-06ea-45ef-87b4-236ac48fa117" xsi:type="SystemSoftware">
+      <name xml:lang="en">Snowflake</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Database</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">8.x</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">540000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-a77f5aeb-6f21-422b-9aae-a59af175d0c6" xsi:type="SystemSoftware">
+      <name xml:lang="en">Tableau Server</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-specialization">
+          <value xml:lang="en">Runtime</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-version">
+          <value xml:lang="en">2024.1</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
+          <value xml:lang="en"></value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
+          <value xml:lang="en">185000.0</value>
+        </property>
+        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
+          <value xml:lang="en">standard</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="DataObject">
+      <name xml:lang="en">Customer</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Sarah Chen (VP Customer Experience)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">confidential</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.91</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">yes</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="DataObject">
+      <name xml:lang="en">Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Mike Torres (Dir. Commerce Engineering)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.94</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="DataObject">
+      <name xml:lang="en">Product</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Lisa Park (Dir. Merchandising)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.96</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="DataObject">
+      <name xml:lang="en">Inventory Position</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Raj Patel (Dir. Supply Chain)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.88</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-a2d9f3e0-7b09-4793-a26f-4531fae7c52f" xsi:type="DataObject">
+      <name xml:lang="en">Payment Transaction</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">David Kim (Dir. Payments)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">restricted</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.99</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">yes</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-63789c6b-9e56-4428-a887-095a10757550" xsi:type="DataObject">
+      <name xml:lang="en">Pet Profile</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Sarah Chen (VP Customer Experience)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">confidential</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.82</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">yes</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="DataObject">
+      <name xml:lang="en">Prescription</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Dr. Amy Roth (Vet Services Lead)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">restricted</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.95</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">yes</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="DataObject">
+      <name xml:lang="en">Subscription</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Jordan Blake (Dir. Subscription)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.9</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-2b2e913f-2e13-4cf5-9ea0-2ab73cf2394f" xsi:type="DataObject">
+      <name xml:lang="en">Vendor</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Raj Patel (Dir. Supply Chain)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.85</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7049951f-839a-4e43-aff4-cda57731b0e3" xsi:type="DataObject">
+      <name xml:lang="en">Financial Transaction</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">CFO Office</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">restricted</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.97</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">yes</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-382a5d6a-6395-406d-afe3-4fb68de8da44" xsi:type="DataObject">
+      <name xml:lang="en">Employee</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">HR Leadership</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">confidential</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.93</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">yes</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-e62c70e4-bc6e-456f-85e2-687e2b1fc77e" xsi:type="DataObject">
+      <name xml:lang="en">Promotion</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Lisa Park (Dir. Merchandising)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.87</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-3a9203d3-ae7b-4714-97d6-54d88f33ed7b" xsi:type="DataObject">
+      <name xml:lang="en">Loyalty Account</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-DataObject-data_steward">
+          <value xml:lang="en">Sarah Chen (VP Customer Experience)</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-classification">
+          <value xml:lang="en">internal</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-quality_score">
+          <value xml:lang="en">0.92</value>
+        </property>
+        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
+          <value xml:lang="en">no</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-9f2c1dc0-e83b-43c7-acf7-9abf3799fe7b" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Capture Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">passthrough</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Validate &amp; Route Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">enrich</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-099b17e2-24b5-4163-a96f-18361e09e48f" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Allocate Inventory</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">filter</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-becccb51-213c-4833-9d24-9c0cb9b33a08" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Authorize Payment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">enrich</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-53e14aff-b9f7-4722-b829-db82f872da1a" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Pick Pack Ship</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">transform</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-4c33bcfe-11a9-460b-ab46-f2791e4d3d79" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Settle Payment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">aggregate</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-873c5197-ce00-47bd-aa75-08276337ebfd" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Post to General Ledger</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">transform</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-a8a0bc44-1b25-49b6-a730-6af2fc8f1b6a" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Master Customer Profile</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">passthrough</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-88df5fe5-5c6b-460d-ac13-d219ea108ff1" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Display Customer Profile</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">filter</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-12cbb986-58b9-4ded-98c8-55ccbfc9b0b5" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Communication Preferences</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">filter</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-7878cb41-2b1c-4955-99b9-62d02166531e" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Customer Analytics Dataset</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">aggregate</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-fd61d8f6-02f8-4575-a31b-dc3c2aad067b" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Record Stock Movement</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">passthrough</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-297950e1-0e3f-40af-afe8-a4af11b3c50b" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Update Inventory Position</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">aggregate</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-2763ea0a-563d-43bc-956b-4d58c43e913a" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Forecast Demand</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">transform</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-bcb0fbce-a0de-4590-a066-79e01b364eb1" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Generate Purchase Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">transform</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-0b1b08a4-3034-4231-86bf-7464b2f613f9" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Notify Supplier</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">filter</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-73c2fa13-b96f-40fd-99f8-dc6ad4af223c" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Evaluate Autoship Eligibility</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">filter</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-8be750d5-0db1-4f1b-9eb4-6f1ce46949e2" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Charge Recurring Payment</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">enrich</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-458b3a66-3547-4368-b37f-f374fb5d1720" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Create Autoship Order</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">transform</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-335e9178-fbd7-47ea-924e-cd64422bf542" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Fulfill Autoship</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">passthrough</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-c4c380b7-a6c3-4721-a71f-237c8dec75d0" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Record Prescription</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">passthrough</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-28d7d045-acc0-4bee-a842-11037e657682" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Validate &amp; Queue Prescription</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">enrich</value>
+        </property>
+      </properties>
+    </element>
+    <element identifier="id-54baed9b-e27b-459d-b57f-da7b5935e6f9" xsi:type="ApplicationProcess">
+      <name xml:lang="en">Notify Customer</name>
+      <properties>
+        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
+          <value xml:lang="en">filter</value>
+        </property>
+      </properties>
+    </element>
+  </elements>
+  <relationships>
+    <relationship identifier="id-fb2b8c8f-f554-4a0e-abea-81dfc0cce6b7" source="id-34722c2c-022c-45bb-942e-cc8a38a875eb" target="id-84b25d10-7046-496e-bf37-ce329675ec09" xsi:type="Composition"/>
+    <relationship identifier="id-3b802fe3-e7ea-4bd1-b01a-e94de8486cab" source="id-34722c2c-022c-45bb-942e-cc8a38a875eb" target="id-c8d7dac0-c947-4394-ab5e-9c39f6de9f11" xsi:type="Composition"/>
+    <relationship identifier="id-960be955-9f3b-4ff6-9137-a0f5f4adeb4c" source="id-34722c2c-022c-45bb-942e-cc8a38a875eb" target="id-643f89dd-aaf9-41ed-8721-6b254ee1e2a3" xsi:type="Composition"/>
+    <relationship identifier="id-206a7e0a-094c-4ea7-b4ab-c706be3c805e" source="id-34722c2c-022c-45bb-942e-cc8a38a875eb" target="id-c3aa4fe1-a75b-4fcf-8e13-6c32f8e2e3c2" xsi:type="Composition"/>
+    <relationship identifier="id-a3abadcc-d75e-4220-a93b-0c09e244fda5" source="id-8b9bdb80-e905-4970-8b03-0c7c7cb36fc5" target="id-321c2bb7-845e-400f-8746-7888dcfe5767" xsi:type="Composition"/>
+    <relationship identifier="id-7533974f-13e3-4963-9e84-7ff4a64ebdec" source="id-8b9bdb80-e905-4970-8b03-0c7c7cb36fc5" target="id-76ad5841-1daf-495b-8979-875d1e10626e" xsi:type="Composition"/>
+    <relationship identifier="id-288ae74d-a002-4948-89de-a5b6427a2d10" source="id-8b9bdb80-e905-4970-8b03-0c7c7cb36fc5" target="id-b7bd6b3f-b0a3-43ce-a960-505ada4294bf" xsi:type="Composition"/>
+    <relationship identifier="id-a1494b1a-6db6-48d1-8d1a-d90cf467c3ff" source="id-8b9bdb80-e905-4970-8b03-0c7c7cb36fc5" target="id-280b7a03-f70d-46e2-bb75-c2fd315ca475" xsi:type="Composition"/>
+    <relationship identifier="id-400bcf02-de19-4660-ac0a-5c44b8d300ea" source="id-8b9bdb80-e905-4970-8b03-0c7c7cb36fc5" target="id-b53d6f34-18f4-4383-aaaf-489dfe5c9ebb" xsi:type="Composition"/>
+    <relationship identifier="id-7008263c-203d-483a-87ff-eb854fe2dad9" source="id-647e2ff6-4bbd-4c58-aaab-753262a00ff8" target="id-3d7e06f8-1b75-42ce-b17a-a4e5eb753f82" xsi:type="Composition"/>
+    <relationship identifier="id-82a51c53-a24e-448b-945f-8ded9b73a1d8" source="id-647e2ff6-4bbd-4c58-aaab-753262a00ff8" target="id-a8a020a1-771a-49f6-a65f-8a4043c85191" xsi:type="Composition"/>
+    <relationship identifier="id-165e0c8e-87fb-4621-b144-175df0ed054c" source="id-647e2ff6-4bbd-4c58-aaab-753262a00ff8" target="id-6fe82059-a0a4-46bc-b394-0cbf02300a8b" xsi:type="Composition"/>
+    <relationship identifier="id-c4330149-7a6a-475e-a0bb-d724b41f2ed1" source="id-b5704b9d-dc39-4f89-8a1b-cb737c8bcd7a" target="id-a4cd67ce-bdef-4f2e-ac75-bdcee15c79b2" xsi:type="Composition"/>
+    <relationship identifier="id-7a828cdc-7646-4676-a139-7fcbb3009219" source="id-b5704b9d-dc39-4f89-8a1b-cb737c8bcd7a" target="id-1310a45e-7787-4f98-80fd-260db0651f40" xsi:type="Composition"/>
+    <relationship identifier="id-eb2d27d2-6b81-415c-b99f-20ebf6d0f467" source="id-b5704b9d-dc39-4f89-8a1b-cb737c8bcd7a" target="id-861aa878-8acb-435e-829f-b186c8d084e2" xsi:type="Composition"/>
+    <relationship identifier="id-566f307d-b54e-4013-8867-bfb16163976d" source="id-b5704b9d-dc39-4f89-8a1b-cb737c8bcd7a" target="id-aaa8fe45-2a6c-4d33-96bc-8b8a266b8a42" xsi:type="Composition"/>
+    <relationship identifier="id-1566fdf0-4a2e-4270-b1e4-980b4b874f9b" source="id-b5704b9d-dc39-4f89-8a1b-cb737c8bcd7a" target="id-5aa6e0bb-2322-4df5-bfde-c2807ea4dced" xsi:type="Composition"/>
+    <relationship identifier="id-4c3cec9f-acb8-405a-ab43-14f3f0ada909" source="id-45212a57-3df1-4d40-9a7a-e0a2078681e7" target="id-de5a5fce-5933-4ffe-b3cc-ac2697074367" xsi:type="Composition"/>
+    <relationship identifier="id-b5faa1a8-4b67-41c2-ac6e-40dfb63bf7eb" source="id-45212a57-3df1-4d40-9a7a-e0a2078681e7" target="id-41b3a772-0cbb-4af4-870e-e68e07c9fd36" xsi:type="Composition"/>
+    <relationship identifier="id-aa521ab6-d4e9-4160-a697-a3ae77d10b20" source="id-45212a57-3df1-4d40-9a7a-e0a2078681e7" target="id-4e6ae9ea-e7a0-472e-9dd9-673d7bed3021" xsi:type="Composition"/>
+    <relationship identifier="id-44c70e8b-0cc5-44a4-bfca-ba4d3fc9b1e1" source="id-4dc6bff3-bc09-416e-b9cc-02da79bc38c3" target="id-900218f9-f570-4592-ba44-8e42c42ce71c" xsi:type="Composition"/>
+    <relationship identifier="id-25615134-5a6c-4562-80ce-822b9ab84700" source="id-4dc6bff3-bc09-416e-b9cc-02da79bc38c3" target="id-06cb31a2-5b2f-4d77-8609-5431ab325b2e" xsi:type="Composition"/>
+    <relationship identifier="id-792d56ee-3a1e-4fb8-8c74-3fc9dbed60df" source="id-4dc6bff3-bc09-416e-b9cc-02da79bc38c3" target="id-85fd9ec2-262c-447a-b84d-d9147331f2a3" xsi:type="Composition"/>
+    <relationship identifier="id-1d165498-6f02-4ab4-bf2a-2245446644d9" source="id-938a7882-81b5-43a4-af92-27b1f21f5f42" target="id-628934c1-822b-4fb1-99ce-d96d693c1001" xsi:type="Composition"/>
+    <relationship identifier="id-2e391dec-5196-4348-ad0e-8167a6e91afe" source="id-938a7882-81b5-43a4-af92-27b1f21f5f42" target="id-144639a3-e342-403f-976e-018d7e88a901" xsi:type="Composition"/>
+    <relationship identifier="id-11deaabe-ca99-48e3-9f6a-08ec820696ad" source="id-938a7882-81b5-43a4-af92-27b1f21f5f42" target="id-484ecf36-d0a6-4b6f-baee-24d0fa5ec337" xsi:type="Composition"/>
+    <relationship identifier="id-24e99e10-d67a-427c-be77-b3c5730ac1c6" source="id-5a27e344-7512-4d16-b67b-10533fc12c29" target="id-83ff968c-9fd1-4102-84df-c24fd8cb28da" xsi:type="Composition"/>
+    <relationship identifier="id-17ae76f2-124e-4547-b748-4f6a62cb61c1" source="id-5a27e344-7512-4d16-b67b-10533fc12c29" target="id-f36f5ac1-27c0-4da3-9832-f869185502e7" xsi:type="Composition"/>
+    <relationship identifier="id-7f406c0b-e2bc-4d32-8464-d6da6e7f3b03" source="id-5a27e344-7512-4d16-b67b-10533fc12c29" target="id-9ef508bf-e5fc-44a8-adbb-59b826cb7523" xsi:type="Composition"/>
+    <relationship identifier="id-59caabf1-7d21-4573-b680-e5b8529d503e" source="id-8d1f9bee-4961-4ac0-9b2a-b1ca8d0d23d2" target="id-5355a765-8ae6-4aff-92c7-1fc889a21874" xsi:type="Composition"/>
+    <relationship identifier="id-dfe8f84a-1995-4963-9047-28ecd1e1b690" source="id-8d1f9bee-4961-4ac0-9b2a-b1ca8d0d23d2" target="id-04d676e8-c319-47a8-9af1-41b6ff63a645" xsi:type="Composition"/>
+    <relationship identifier="id-a4d05119-7dd1-489c-8fc8-82443bce21c1" source="id-8d1f9bee-4961-4ac0-9b2a-b1ca8d0d23d2" target="id-759f84bd-36a1-416a-bd39-c4ca3fc96730" xsi:type="Composition"/>
+    <relationship identifier="id-685f9db3-9799-4a0c-94a3-1e35d7f7cd0d" source="id-7f436d2a-62f5-40f3-9740-8f30ce1f3ee5" target="id-55eaf96b-a07e-4d60-ad86-6d568e39fbf3" xsi:type="Composition"/>
+    <relationship identifier="id-b1f27d1b-9ae3-48ee-8e5d-9a612b17b2e8" source="id-7f436d2a-62f5-40f3-9740-8f30ce1f3ee5" target="id-09566991-6f25-4d6d-9f1c-8af118f70ac9" xsi:type="Composition"/>
+    <relationship identifier="id-3fc6afa4-e722-4ea2-a2df-6529a6661c43" source="id-7f436d2a-62f5-40f3-9740-8f30ce1f3ee5" target="id-e88fb54e-74e1-4c32-b324-c94cfedd9d1f" xsi:type="Composition"/>
+    <relationship identifier="id-7198643b-591f-48b8-97fb-75673ad88be4" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-321c2bb7-845e-400f-8746-7888dcfe5767" xsi:type="Realization"/>
+    <relationship identifier="id-8787f596-ae52-4342-897d-8fce5ad64782" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-b53d6f34-18f4-4383-aaaf-489dfe5c9ebb" xsi:type="Realization"/>
+    <relationship identifier="id-3d2447b2-95db-4c24-960b-b08c67103dba" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-b7bd6b3f-b0a3-43ce-a960-505ada4294bf" xsi:type="Realization"/>
+    <relationship identifier="id-21e8cf92-577e-46c2-a1f8-f0ba6bcb9a76" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-84b25d10-7046-496e-bf37-ce329675ec09" xsi:type="Realization"/>
+    <relationship identifier="id-42e37703-a9bc-483f-8d70-39dc3c1af78b" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-76ad5841-1daf-495b-8979-875d1e10626e" xsi:type="Realization"/>
+    <relationship identifier="id-2028e85d-53e5-498b-a3fc-be25a479a09c" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-643f89dd-aaf9-41ed-8721-6b254ee1e2a3" xsi:type="Realization"/>
+    <relationship identifier="id-82258679-9cc4-421e-b4fd-f68f874fa41c" source="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" target="id-643f89dd-aaf9-41ed-8721-6b254ee1e2a3" xsi:type="Realization"/>
+    <relationship identifier="id-0dc780e4-2310-423f-8e40-356f2ecdebe7" source="id-1dea16af-8743-455c-a0d2-940006778981" target="id-280b7a03-f70d-46e2-bb75-c2fd315ca475" xsi:type="Realization"/>
+    <relationship identifier="id-f233e1e0-bec1-4e00-a19a-8a3318538fc0" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-c8d7dac0-c947-4394-ab5e-9c39f6de9f11" xsi:type="Realization"/>
+    <relationship identifier="id-b24b707d-331e-4691-b1de-91bae0a76257" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-84b25d10-7046-496e-bf37-ce329675ec09" xsi:type="Realization"/>
+    <relationship identifier="id-f6de3097-4e7e-45f1-88be-416029c6acce" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-c3aa4fe1-a75b-4fcf-8e13-6c32f8e2e3c2" xsi:type="Realization"/>
+    <relationship identifier="id-1eca9d66-c4b1-4134-9c8a-d60de853eb3f" source="id-9f312eed-cd28-4dce-965f-9549b0b22b72" target="id-3d7e06f8-1b75-42ce-b17a-a4e5eb753f82" xsi:type="Realization"/>
+    <relationship identifier="id-a43484bd-069d-47a0-a603-90b4909f483e" source="id-5a359712-886b-410c-a811-6a37d9728fad" target="id-6fe82059-a0a4-46bc-b394-0cbf02300a8b" xsi:type="Realization"/>
+    <relationship identifier="id-ecde5e89-1e24-4089-b046-2d27b55de086" source="id-5a359712-886b-410c-a811-6a37d9728fad" target="id-a8a020a1-771a-49f6-a65f-8a4043c85191" xsi:type="Realization"/>
+    <relationship identifier="id-814683b2-9e7d-40fd-af6b-02d1f6ae92e2" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-a4cd67ce-bdef-4f2e-ac75-bdcee15c79b2" xsi:type="Realization"/>
+    <relationship identifier="id-b2a6db0f-ec4c-48e9-9b6a-1b52895c4e02" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-aaa8fe45-2a6c-4d33-96bc-8b8a266b8a42" xsi:type="Realization"/>
+    <relationship identifier="id-58968521-ed92-4a2d-b5cf-0fd292755c01" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-1310a45e-7787-4f98-80fd-260db0651f40" xsi:type="Realization"/>
+    <relationship identifier="id-eca8cdad-89e5-46da-ad18-6190f6225b6b" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-861aa878-8acb-435e-829f-b186c8d084e2" xsi:type="Realization"/>
+    <relationship identifier="id-a896eeb5-bace-46a2-a3cd-7e9e2bc1c9bb" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-861aa878-8acb-435e-829f-b186c8d084e2" xsi:type="Realization"/>
+    <relationship identifier="id-126fcd34-043d-4c2c-836f-4663defe73b6" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-5aa6e0bb-2322-4df5-bfde-c2807ea4dced" xsi:type="Realization"/>
+    <relationship identifier="id-3e3d0136-53ef-44a9-b4bb-8424372e1f4b" source="id-3342d891-a82d-490a-846d-00b5a0074c1c" target="id-5aa6e0bb-2322-4df5-bfde-c2807ea4dced" xsi:type="Realization"/>
+    <relationship identifier="id-7a515d99-0c8f-44a9-aab8-39de98ea25d5" source="id-9c6344bc-55b8-48d3-8740-543c4f22b773" target="id-de5a5fce-5933-4ffe-b3cc-ac2697074367" xsi:type="Realization"/>
+    <relationship identifier="id-7b09b658-8a68-422f-b7df-f2ece4201bf1" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-41b3a772-0cbb-4af4-870e-e68e07c9fd36" xsi:type="Realization"/>
+    <relationship identifier="id-be63c02a-14c0-4745-87c6-4469e3289a55" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-4e6ae9ea-e7a0-472e-9dd9-673d7bed3021" xsi:type="Realization"/>
+    <relationship identifier="id-6287d8f5-cc7c-4870-a507-64d8ea0e045a" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-900218f9-f570-4592-ba44-8e42c42ce71c" xsi:type="Realization"/>
+    <relationship identifier="id-7ed50300-4a18-4a6f-8184-5a19afd10e17" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-06cb31a2-5b2f-4d77-8609-5431ab325b2e" xsi:type="Realization"/>
+    <relationship identifier="id-d92e6b1b-5490-4fe4-b62b-8aeaa405388f" source="id-38608a00-6935-4cbb-b182-3e345311d32e" target="id-85fd9ec2-262c-447a-b84d-d9147331f2a3" xsi:type="Realization"/>
+    <relationship identifier="id-6a4d2150-e486-42cf-9666-cca2b2dc2b44" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-628934c1-822b-4fb1-99ce-d96d693c1001" xsi:type="Realization"/>
+    <relationship identifier="id-49a75e1d-d0fc-4ef1-b706-ff8339e1e37e" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-144639a3-e342-403f-976e-018d7e88a901" xsi:type="Realization"/>
+    <relationship identifier="id-6e439bb5-46b1-4e17-821f-3670840a290c" source="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" target="id-484ecf36-d0a6-4b6f-baee-24d0fa5ec337" xsi:type="Realization"/>
+    <relationship identifier="id-5f9fde12-f853-41b7-add3-942aedbd24fc" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-83ff968c-9fd1-4102-84df-c24fd8cb28da" xsi:type="Realization"/>
+    <relationship identifier="id-999a6145-9107-4e51-a8ff-569c7eb1d355" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-f36f5ac1-27c0-4da3-9832-f869185502e7" xsi:type="Realization"/>
+    <relationship identifier="id-41ec1e1a-a06a-44cf-9d4c-1f3818ce894f" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-9ef508bf-e5fc-44a8-adbb-59b826cb7523" xsi:type="Realization"/>
+    <relationship identifier="id-56ad9965-126f-4280-9d8e-f1cabbb484cd" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-5355a765-8ae6-4aff-92c7-1fc889a21874" xsi:type="Realization"/>
+    <relationship identifier="id-33826f4d-fcbc-4c25-8b4a-782a380efab6" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-06cb31a2-5b2f-4d77-8609-5431ab325b2e" xsi:type="Realization"/>
+    <relationship identifier="id-b0525a29-0dcf-4fba-bc35-1989e0ba909e" source="id-cd6afa27-4621-405a-882a-1b059cab5b30" target="id-04d676e8-c319-47a8-9af1-41b6ff63a645" xsi:type="Realization"/>
+    <relationship identifier="id-b58d9948-2231-4f19-982d-f3f4ebcc10f0" source="id-dfd92e6a-82cc-4340-a5a6-3f07c9b96acf" target="id-759f84bd-36a1-416a-bd39-c4ca3fc96730" xsi:type="Realization"/>
+    <relationship identifier="id-21c5afe6-6b82-4684-be99-260cc64e9554" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-55eaf96b-a07e-4d60-ad86-6d568e39fbf3" xsi:type="Realization"/>
+    <relationship identifier="id-c12a9cd1-f439-40d7-b472-036b0a765068" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-09566991-6f25-4d6d-9f1c-8af118f70ac9" xsi:type="Realization"/>
+    <relationship identifier="id-5b51af55-a708-4a10-92bb-90514b0f26a9" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-e88fb54e-74e1-4c32-b324-c94cfedd9d1f" xsi:type="Realization"/>
+    <relationship identifier="id-628afeee-08e5-4f91-be34-799509a5b395" source="id-ddd07811-d0ae-4faa-b803-1f8c49e53fa1" target="id-55eaf96b-a07e-4d60-ad86-6d568e39fbf3" xsi:type="Realization"/>
+    <relationship identifier="id-254f5f05-1785-422a-9c38-690e619e9104" source="id-d7defcd1-0807-4544-9b70-1343cd2f42fa" target="id-55eaf96b-a07e-4d60-ad86-6d568e39fbf3" xsi:type="Realization"/>
+    <relationship identifier="id-524ab025-45a0-4afc-90bf-b3571fb01d98" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-3b586ae3-8f43-4766-b3ff-131a57d3f66b" xsi:type="Realization"/>
+    <relationship identifier="id-25da7f1e-5f24-4913-a562-47cc186a2c01" source="id-3b586ae3-8f43-4766-b3ff-131a57d3f66b" target="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="Serving"/>
+    <relationship identifier="id-105ea78d-cc17-4a66-93a9-e86f229b04e3" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-d92cdc26-7b92-428f-b49d-86dab9ecfde2" xsi:type="Composition"/>
+    <relationship identifier="id-194e8673-a61f-4d50-8db4-25175ae9d0b4" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-f7c3a569-3239-4622-988e-5056a5424ddd" xsi:type="Realization"/>
+    <relationship identifier="id-9ddb9f5c-0cfd-46c6-be05-d3e016e35209" source="id-f7c3a569-3239-4622-988e-5056a5424ddd" target="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="Serving"/>
+    <relationship identifier="id-ca61d89c-24ff-4dc5-841b-7aadd5e905cd" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-4c8b46d5-8bfa-494e-beba-43f495203e95" xsi:type="Composition"/>
+    <relationship identifier="id-09d6e9d4-1e97-423e-8ec1-bcba78b86856" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-6660f496-212d-4d43-a5e3-33a1aabd94b1" xsi:type="Realization"/>
+    <relationship identifier="id-6480119d-908d-403f-8e6c-e3a4a131bbb0" source="id-6660f496-212d-4d43-a5e3-33a1aabd94b1" target="id-9f312eed-cd28-4dce-965f-9549b0b22b72" xsi:type="Serving"/>
+    <relationship identifier="id-809b119e-d0b2-4d41-bb24-a11922a8184c" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-46ac206c-a820-4e67-80f1-360adce42e10" xsi:type="Composition"/>
+    <relationship identifier="id-52927d9a-70fa-4e53-8147-7a8cc2fe4475" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-8caa491c-7166-4831-a3e7-17e8b383b2f9" xsi:type="Realization"/>
+    <relationship identifier="id-d222bf1d-75b9-4da8-8910-9e794576145d" source="id-8caa491c-7166-4831-a3e7-17e8b383b2f9" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Serving"/>
+    <relationship identifier="id-99c7af79-a761-4928-9398-d41ea86382a1" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-8b33a653-43af-46bb-a442-915e399aefb0" xsi:type="Composition"/>
+    <relationship identifier="id-79f6822c-591f-4e98-be1c-7653b3e0e76a" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-46b732ca-7dc0-461a-a80d-094d0956a6a4" xsi:type="Realization"/>
+    <relationship identifier="id-b0f2b0ce-b453-4539-a7e0-63a535566306" source="id-46b732ca-7dc0-461a-a80d-094d0956a6a4" target="id-9c6344bc-55b8-48d3-8740-543c4f22b773" xsi:type="Serving"/>
+    <relationship identifier="id-ccf34f93-f29f-4476-afe7-6952526775f4" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-3cef0cab-3dd6-45e3-83ed-202a633c3270" xsi:type="Composition"/>
+    <relationship identifier="id-21b50cac-cdd7-481b-a5ce-8f7e39cc5cb2" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-05826787-3bf2-4310-8b54-13e3327c7c04" xsi:type="Realization"/>
+    <relationship identifier="id-dfc9c8b4-6e1d-43fa-a19e-63d12097346c" source="id-05826787-3bf2-4310-8b54-13e3327c7c04" target="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" xsi:type="Serving"/>
+    <relationship identifier="id-58193395-31ae-4280-a874-94ecb11d49c1" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-3796b2a7-8475-48de-bd42-da09dadea6af" xsi:type="Composition"/>
+    <relationship identifier="id-d7ca1822-eb4e-4d0f-b5b0-792128a15247" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-58252994-6799-4172-b41c-7b0bc3618f4e" xsi:type="Realization"/>
+    <relationship identifier="id-69fc8e84-9eac-4891-b6b1-f676ab48680f" source="id-58252994-6799-4172-b41c-7b0bc3618f4e" target="id-1dea16af-8743-455c-a0d2-940006778981" xsi:type="Serving"/>
+    <relationship identifier="id-4060baee-b3e0-4af3-8e10-9d82139d4800" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-104010de-beeb-4697-8422-0ddb3c682bb7" xsi:type="Composition"/>
+    <relationship identifier="id-8c22b727-372b-4d55-aa68-4ac9399945a3" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-a5f6f044-a46a-4538-bb93-3a2ee21fb744" xsi:type="Realization"/>
+    <relationship identifier="id-83abc1a2-e26a-4d26-ba93-f9cc6fd3444c" source="id-a5f6f044-a46a-4538-bb93-3a2ee21fb744" target="id-9c6344bc-55b8-48d3-8740-543c4f22b773" xsi:type="Serving"/>
+    <relationship identifier="id-77e97ebc-2916-4745-b72b-223f19f7e659" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-12a212d2-51f4-41c1-8ec5-eca24044863b" xsi:type="Composition"/>
+    <relationship identifier="id-a9f3949e-fdc6-42d2-a75c-83e924da47f6" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-5b56ddc9-0551-4618-9340-8d0cf8b56a42" xsi:type="Realization"/>
+    <relationship identifier="id-2b5a2590-583a-423f-b3e6-38397e5b7d88" source="id-5b56ddc9-0551-4618-9340-8d0cf8b56a42" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Serving"/>
+    <relationship identifier="id-180935bd-72f9-4081-a6de-b1c7541753d1" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-e828f946-5f7f-4070-b182-bce94422bc7b" xsi:type="Composition"/>
+    <relationship identifier="id-50847d37-a0c6-43c8-a8ee-2f5e2a8e3940" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-44984b3f-3902-4f80-9c70-dd38e9a8e8de" xsi:type="Realization"/>
+    <relationship identifier="id-a7f6e806-127a-4d2d-8d1c-07e3988fb3e5" source="id-44984b3f-3902-4f80-9c70-dd38e9a8e8de" target="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" xsi:type="Serving"/>
+    <relationship identifier="id-451ebadc-7f36-4707-b31a-9fe2bcefa88b" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-f6b51463-186c-45e8-bca1-342f5fcb0831" xsi:type="Composition"/>
+    <relationship identifier="id-3cd3436e-a96a-4326-8826-ea25536e1d55" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-7b6b9bf5-273d-4dc5-b179-b0783c185a83" xsi:type="Realization"/>
+    <relationship identifier="id-e38da95e-6e9a-4e11-b2f9-8398fea6f713" source="id-7b6b9bf5-273d-4dc5-b179-b0783c185a83" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Serving"/>
+    <relationship identifier="id-6e9f2fd7-c87e-4b8b-a6f2-3548edcadc8e" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-6312b769-1930-486d-b0b8-0511865f84b5" xsi:type="Composition"/>
+    <relationship identifier="id-8405aa21-ff39-40e0-a8c8-2177699f91f5" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-d38f73b7-569d-411d-bfa0-ca31fd62f75a" xsi:type="Realization"/>
+    <relationship identifier="id-7308ebaa-a0de-4cdd-9bdf-44876556ff11" source="id-d38f73b7-569d-411d-bfa0-ca31fd62f75a" target="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" xsi:type="Serving"/>
+    <relationship identifier="id-76180d49-90e9-47e7-8330-e52882c661cf" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-ef756bf4-b051-478c-8446-b5231f6e0dee" xsi:type="Composition"/>
+    <relationship identifier="id-f3c551cd-ce37-4e21-a8e0-731b61315b11" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-670037f8-e7de-46b5-be8a-10bf505c9b80" xsi:type="Realization"/>
+    <relationship identifier="id-876a194b-b0c4-4b9e-94c3-06629d8122d7" source="id-670037f8-e7de-46b5-be8a-10bf505c9b80" target="id-306f394a-2e02-4fd3-bb7e-8475e756652c" xsi:type="Serving"/>
+    <relationship identifier="id-dbbe0b42-5d44-40aa-be95-9791cd4ef2aa" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-7b966d33-573f-4b2f-a123-d6c712edad31" xsi:type="Composition"/>
+    <relationship identifier="id-c31af09c-523c-44e4-b2f5-6f38801ab1d9" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-d085d7d6-8935-424f-9912-a2f920d37fa1" xsi:type="Realization"/>
+    <relationship identifier="id-71bc7110-a5e0-4805-8bcb-19ffeae64685" source="id-d085d7d6-8935-424f-9912-a2f920d37fa1" target="id-3342d891-a82d-490a-846d-00b5a0074c1c" xsi:type="Serving"/>
+    <relationship identifier="id-7c337747-a466-4c33-a4f9-7089ddc00f16" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-b439cc07-44c6-4ba8-98bb-ce33cfbd7f62" xsi:type="Composition"/>
+    <relationship identifier="id-d6245e84-fdc8-4c1e-a998-ccec937df31b" source="id-9c6344bc-55b8-48d3-8740-543c4f22b773" target="id-9e7c5c6b-7930-444c-ac37-3d0f54043475" xsi:type="Realization"/>
+    <relationship identifier="id-05fda303-f3cc-460f-b119-8cb7dfc84058" source="id-9e7c5c6b-7930-444c-ac37-3d0f54043475" target="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" xsi:type="Serving"/>
+    <relationship identifier="id-32453aa7-a82d-4ae1-8d54-b3c5abbfd440" source="id-9c6344bc-55b8-48d3-8740-543c4f22b773" target="id-9849fe68-1419-4511-a5bf-a10e8f89a7fd" xsi:type="Composition"/>
+    <relationship identifier="id-137719f3-55cb-44f6-95b8-68fd4bf2d588" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-52ad528d-5159-463d-9cd5-8543c381492a" xsi:type="Realization"/>
+    <relationship identifier="id-8ae04144-2c1a-4844-a9fe-6d35171baa83" source="id-52ad528d-5159-463d-9cd5-8543c381492a" target="id-616f25a9-5656-47dd-a0a4-e69c0532b230" xsi:type="Serving"/>
+    <relationship identifier="id-2cce7d34-efd1-4ca7-9fd2-2e9fc4c1cd0b" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-08f482ea-2b3e-438e-aa3e-d3c306e4e1c2" xsi:type="Composition"/>
+    <relationship identifier="id-796745f1-70fc-4db2-b652-16a79f6ea97c" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-5c30ad43-e46d-4ced-8eca-64c40fca888b" xsi:type="Realization"/>
+    <relationship identifier="id-ab68f8c3-794a-43e0-830c-132f500045d5" source="id-5c30ad43-e46d-4ced-8eca-64c40fca888b" target="id-d2228401-402d-4814-a860-9d9f3f762460" xsi:type="Serving"/>
+    <relationship identifier="id-b123348f-4e14-484f-9f4a-34bee1f28179" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-7405dc79-410b-40eb-874d-29a8851c3f53" xsi:type="Composition"/>
+    <relationship identifier="id-a836ee77-6359-41d0-9cff-256c168055d1" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-06b220fe-1d24-46ff-a689-2faa8df89d74" xsi:type="Realization"/>
+    <relationship identifier="id-3d2366a6-90fb-46a5-b8ca-c002eee406af" source="id-06b220fe-1d24-46ff-a689-2faa8df89d74" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Serving"/>
+    <relationship identifier="id-a4cc5cc6-531c-473e-a171-98c669d827cb" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-244ab6dc-71ee-4484-97f1-0e384d1bda51" xsi:type="Composition"/>
+    <relationship identifier="id-efa000cc-0b43-4820-9c29-53c7f393cc10" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-bb4472ba-07e1-41ce-b033-1ae83cf47216" xsi:type="Realization"/>
+    <relationship identifier="id-d707d230-6c42-4a1d-a0d3-466f4531f52e" source="id-bb4472ba-07e1-41ce-b033-1ae83cf47216" target="id-616f25a9-5656-47dd-a0a4-e69c0532b230" xsi:type="Serving"/>
+    <relationship identifier="id-aba87f87-b995-4dde-8cc9-b0b9936c6676" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-4291a914-8df2-4ad8-9c0e-e096a54e3c17" xsi:type="Composition"/>
+    <relationship identifier="id-9ee48b7e-5cea-45d8-a016-9dda4834e9a8" source="id-5a359712-886b-410c-a811-6a37d9728fad" target="id-3d464bc5-d993-4c02-a102-fba7c9e74d63" xsi:type="Realization"/>
+    <relationship identifier="id-a2ac4ccd-e4c6-44fa-93c1-03c70e827e27" source="id-3d464bc5-d993-4c02-a102-fba7c9e74d63" target="id-38608a00-6935-4cbb-b182-3e345311d32e" xsi:type="Serving"/>
+    <relationship identifier="id-a036cb04-6878-48f8-8fa5-041f67035fa7" source="id-5a359712-886b-410c-a811-6a37d9728fad" target="id-c7ea0074-18d8-40d6-aec5-f87f0a6cf7e2" xsi:type="Composition"/>
+    <relationship identifier="id-86f1b02f-d2c4-4592-abac-3b3c19f7c41a" source="id-38608a00-6935-4cbb-b182-3e345311d32e" target="id-4f1b0e08-15c9-4468-84fe-65c6e4e03e1b" xsi:type="Realization"/>
+    <relationship identifier="id-f11cde94-403c-4137-9e04-8255bff28ae5" source="id-4f1b0e08-15c9-4468-84fe-65c6e4e03e1b" target="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" xsi:type="Serving"/>
+    <relationship identifier="id-daad2271-c703-4a65-8bb1-8a561ae4f471" source="id-38608a00-6935-4cbb-b182-3e345311d32e" target="id-c31d186c-7fd4-402d-9d43-537303125ec4" xsi:type="Composition"/>
+    <relationship identifier="id-a066e682-8467-473e-a6ac-6f9915ba71df" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-e7c1a5af-2d0f-4ca3-bf31-17d146eff0e9" xsi:type="Realization"/>
+    <relationship identifier="id-02776386-562f-485b-b6d6-226d42b9948f" source="id-e7c1a5af-2d0f-4ca3-bf31-17d146eff0e9" target="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="Serving"/>
+    <relationship identifier="id-4d6acab5-95cd-4664-848c-52570afe749a" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-ca4cdad6-3f2c-40d8-a9b7-bc5ef3be46b9" xsi:type="Composition"/>
+    <relationship identifier="id-5cb51941-a7de-4a4a-a153-9830e4cc19f8" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-54d82289-dd2c-4322-8a03-bef08ab4cf05" xsi:type="Realization"/>
+    <relationship identifier="id-924f29f5-cd00-46ed-8b4c-5689f09f9c13" source="id-54d82289-dd2c-4322-8a03-bef08ab4cf05" target="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" xsi:type="Serving"/>
+    <relationship identifier="id-daa7ff45-cc79-4116-b9d2-cd63fcd42175" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-5cdaa285-8bef-438d-ac35-1e4f07fd0776" xsi:type="Composition"/>
+    <relationship identifier="id-fece33b1-9018-4eb4-891d-4f786ca243ab" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-7d8eb0f3-1df3-49cc-8846-9735ce26b71e" xsi:type="Realization"/>
+    <relationship identifier="id-0f264059-eb9e-4b9d-8de5-259caabec6be" source="id-7d8eb0f3-1df3-49cc-8846-9735ce26b71e" target="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="Serving"/>
+    <relationship identifier="id-90626c2b-60a4-43cb-b1bc-d2948df1ace8" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-5cf60122-c43b-4b47-9bb1-0c6880ef1f1b" xsi:type="Composition"/>
+    <relationship identifier="id-2f842234-2d1e-4657-9f12-983d2f7f368b" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-99721a11-d4ee-40a7-a8e8-fb8542229afa" xsi:type="Realization"/>
+    <relationship identifier="id-1be8be03-0baf-4de1-83eb-d9571092207c" source="id-99721a11-d4ee-40a7-a8e8-fb8542229afa" target="id-9c6344bc-55b8-48d3-8740-543c4f22b773" xsi:type="Serving"/>
+    <relationship identifier="id-5d511bcb-32a4-4622-b6cc-3af479e51a0a" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-dc8e7cba-fdaa-41e0-94b7-45f013bc5a89" xsi:type="Composition"/>
+    <relationship identifier="id-104f28bb-9a36-47b8-8091-8c6ee7f52177" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-1edd1f68-c2d9-47ed-b78e-7e48554ad4f1" xsi:type="Realization"/>
+    <relationship identifier="id-f629b0ed-da2a-4378-8468-139fa6ea7933" source="id-1edd1f68-c2d9-47ed-b78e-7e48554ad4f1" target="id-306f394a-2e02-4fd3-bb7e-8475e756652c" xsi:type="Serving"/>
+    <relationship identifier="id-5c3fc2f8-35d0-4a2c-823a-40f81f49b842" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-c13be14f-b294-43ed-b05e-ec441198058f" xsi:type="Composition"/>
+    <relationship identifier="id-fc40a76a-c0cb-4a25-87e4-106e81f1d8fa" source="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" target="id-8c9e2f9c-0ab8-4e56-b5d2-b37fd16ee4b4" xsi:type="Realization"/>
+    <relationship identifier="id-cef63a05-0063-49eb-8bdc-c4a25bd1320e" source="id-8c9e2f9c-0ab8-4e56-b5d2-b37fd16ee4b4" target="id-306f394a-2e02-4fd3-bb7e-8475e756652c" xsi:type="Serving"/>
+    <relationship identifier="id-475c47bc-987b-4a75-ad56-4d8ba9b6c2ed" source="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" target="id-9628c856-2c41-4b45-bc51-359af00b6f74" xsi:type="Composition"/>
+    <relationship identifier="id-f8bea3b4-8750-4777-b249-6ca24fa28397" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-d35e68eb-0ab9-4217-9d65-8798dbcd92d0" xsi:type="Realization"/>
+    <relationship identifier="id-b4c75320-dd22-468d-ad57-a6de49058d05" source="id-d35e68eb-0ab9-4217-9d65-8798dbcd92d0" target="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="Serving"/>
+    <relationship identifier="id-ddeaf014-9f17-48f6-81c6-55ce60340893" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-618e1e84-bb38-4d14-96eb-195f6ca93479" xsi:type="Composition"/>
+    <relationship identifier="id-2fb23c34-0bd2-4269-872f-1ed8c4548070" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-e7f2a495-748a-4013-a86f-575f2d9c993e" xsi:type="Realization"/>
+    <relationship identifier="id-79d6babf-0433-4df1-89c9-f369b7c86834" source="id-e7f2a495-748a-4013-a86f-575f2d9c993e" target="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="Serving"/>
+    <relationship identifier="id-6759a67e-b28e-43fc-a652-d653bc24a9db" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-bd2b16fb-71c0-41bf-923a-47fbc5aa08a6" xsi:type="Composition"/>
+    <relationship identifier="id-ba72fc30-a58f-4e77-b1f6-807da3ccc554" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-b0efa90b-92c0-4438-bd5a-d39830fb85b4" xsi:type="Realization"/>
+    <relationship identifier="id-b87621bf-5b32-4c1f-86c4-52c426728160" source="id-b0efa90b-92c0-4438-bd5a-d39830fb85b4" target="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="Serving"/>
+    <relationship identifier="id-b4ab219b-6d08-47e8-bd07-876df1391d4f" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-1b6d8cd3-5f8b-425b-b9c5-a5d02452ee0c" xsi:type="Composition"/>
+    <relationship identifier="id-f29a71a2-5090-4d81-9e8c-aa7898c00b20" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-f70216ed-37b1-4adb-b188-7984ba39c4cb" xsi:type="Realization"/>
+    <relationship identifier="id-1b105674-ca60-4bdd-9bee-ae9eecd5c262" source="id-f70216ed-37b1-4adb-b188-7984ba39c4cb" target="id-ddd07811-d0ae-4faa-b803-1f8c49e53fa1" xsi:type="Serving"/>
+    <relationship identifier="id-e7eac2e5-b267-49db-919e-4a846e275f0b" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-baaf9a2e-52b3-434c-bd1a-d48bb5a5f744" xsi:type="Composition"/>
+    <relationship identifier="id-b644a52e-fbcf-46e0-be6b-14553197b800" source="id-d7defcd1-0807-4544-9b70-1343cd2f42fa" target="id-b88fe301-4784-4b2e-bcc5-f650510a0fbd" xsi:type="Realization"/>
+    <relationship identifier="id-c13d6b11-6246-4ced-90bc-225a8b5a4f95" source="id-b88fe301-4784-4b2e-bcc5-f650510a0fbd" target="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="Serving"/>
+    <relationship identifier="id-213d55d4-3ee7-4d91-b65e-c591b0390a4d" source="id-d7defcd1-0807-4544-9b70-1343cd2f42fa" target="id-86af5225-cfe5-4d85-aa78-f55f4cfdc410" xsi:type="Composition"/>
+    <relationship identifier="id-83db2f29-d706-42d1-9075-f2d446fa02b0" source="id-d713582c-3420-46bc-89e2-50a210639fcf" target="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" xsi:type="Realization"/>
+    <relationship identifier="id-9e936aa1-fa87-4812-9458-7360fe592c57" source="id-d713582c-3420-46bc-89e2-50a210639fcf" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Realization"/>
+    <relationship identifier="id-7fff6686-2309-4387-8cf8-86ff92579cac" source="id-d713582c-3420-46bc-89e2-50a210639fcf" target="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="Realization"/>
+    <relationship identifier="id-deb07181-8911-4d0f-8cc3-ba2b780a8716" source="id-d713582c-3420-46bc-89e2-50a210639fcf" target="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" xsi:type="Realization"/>
+    <relationship identifier="id-1587d371-327c-4b30-abfb-5ef325736957" source="id-d713582c-3420-46bc-89e2-50a210639fcf" target="id-1dea16af-8743-455c-a0d2-940006778981" xsi:type="Realization"/>
+    <relationship identifier="id-51431ad6-4a22-49c2-a5c7-d1731f393256" source="id-5870ddac-a467-4383-aae3-73b65edd402e" target="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="Realization"/>
+    <relationship identifier="id-fb69c054-6418-48e8-b87d-277fcd2d9969" source="id-5870ddac-a467-4383-aae3-73b65edd402e" target="id-306f394a-2e02-4fd3-bb7e-8475e756652c" xsi:type="Realization"/>
+    <relationship identifier="id-719abb49-401b-44d6-ba23-d10fb6dd8ce5" source="id-5870ddac-a467-4383-aae3-73b65edd402e" target="id-9f312eed-cd28-4dce-965f-9549b0b22b72" xsi:type="Realization"/>
+    <relationship identifier="id-016d0467-0a54-429e-b6da-cc124ef0e19f" source="id-5870ddac-a467-4383-aae3-73b65edd402e" target="id-9c6344bc-55b8-48d3-8740-543c4f22b773" xsi:type="Realization"/>
+    <relationship identifier="id-3c2c0647-7423-405c-9222-34a865a0d078" source="id-c365642e-6789-4cdf-8525-5bcaee529a0e" target="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" xsi:type="Realization"/>
+    <relationship identifier="id-0b67b695-ae33-495e-94e8-717dcad07ad5" source="id-c365642e-6789-4cdf-8525-5bcaee529a0e" target="id-d2228401-402d-4814-a860-9d9f3f762460" xsi:type="Realization"/>
+    <relationship identifier="id-dae654d6-adbd-4eaf-84c8-b46003cc232a" source="id-c365642e-6789-4cdf-8525-5bcaee529a0e" target="id-38608a00-6935-4cbb-b182-3e345311d32e" xsi:type="Realization"/>
+    <relationship identifier="id-f4197432-b167-4cc9-9939-82fb9d7574e5" source="id-14205d21-6763-4964-82f0-788d63fd2c41" target="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" xsi:type="Realization"/>
+    <relationship identifier="id-c2d6bb8e-9c7b-4acf-b3dd-23ae1e9c9342" source="id-14205d21-6763-4964-82f0-788d63fd2c41" target="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" xsi:type="Realization"/>
+    <relationship identifier="id-5b067922-2dba-47dd-8dd6-74c3a99e9b55" source="id-14205d21-6763-4964-82f0-788d63fd2c41" target="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" xsi:type="Realization"/>
+    <relationship identifier="id-551c0f89-afe7-4711-9318-76c9a6df4fd7" source="id-1140ce13-3ccf-4f24-be1e-fc9e794a7985" target="id-e56a1711-cd55-483f-8c46-f52c420e0476" xsi:type="Realization"/>
+    <relationship identifier="id-44546df5-c79a-43ca-97f9-690bdb4ecea6" source="id-551c1ee0-69f1-42a2-b981-a7aff38ba20c" target="id-616f25a9-5656-47dd-a0a4-e69c0532b230" xsi:type="Realization"/>
+    <relationship identifier="id-144ca61b-9931-4965-85c2-b2092b18d399" source="id-41c147f3-7d6b-4a09-9356-cb53a2b46fc2" target="id-3342d891-a82d-490a-846d-00b5a0074c1c" xsi:type="Realization"/>
+    <relationship identifier="id-a88dfa28-18f1-4ef1-a6a7-98e07da2637e" source="id-1f21b9e8-44d4-450d-8c9d-28bec472d4dc" target="id-cd6afa27-4621-405a-882a-1b059cab5b30" xsi:type="Realization"/>
+    <relationship identifier="id-f452e2c1-9ccb-42aa-83d1-ed7e7823dba7" source="id-7d9353c1-69d8-4674-b80b-8a731fc72e17" target="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" xsi:type="Realization"/>
+    <relationship identifier="id-e1e38d37-f493-42fb-8044-d2ecf40583e6" source="id-7d9353c1-69d8-4674-b80b-8a731fc72e17" target="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="Realization"/>
+    <relationship identifier="id-feed4e2d-0442-43d4-bb1b-0aff75736b2a" source="id-7d9353c1-69d8-4674-b80b-8a731fc72e17" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Realization"/>
+    <relationship identifier="id-a0eb5aa7-336f-4ef3-b722-c36a99b1af53" source="id-78df0baa-84ff-40d1-9491-a08d5ec6c549" target="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="Realization"/>
+    <relationship identifier="id-900eead1-8294-41eb-a6fe-9755a1bb8b9b" source="id-78df0baa-84ff-40d1-9491-a08d5ec6c549" target="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" xsi:type="Realization"/>
+    <relationship identifier="id-669cbe95-f214-4712-86e8-7bda7cf59f7a" source="id-78df0baa-84ff-40d1-9491-a08d5ec6c549" target="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" xsi:type="Realization"/>
+    <relationship identifier="id-10155f39-f457-459f-b32c-63b2174f741a" source="id-f7fc19e3-aae0-42d3-a85c-a84a23d7b15e" target="id-9f312eed-cd28-4dce-965f-9549b0b22b72" xsi:type="Realization"/>
+    <relationship identifier="id-544d0b87-b6f3-408a-a352-9e886472a618" source="id-f7fc19e3-aae0-42d3-a85c-a84a23d7b15e" target="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" xsi:type="Realization"/>
+    <relationship identifier="id-077a77e9-be40-47cc-a41e-66b2998fe947" source="id-d94110fc-ff5c-488d-a115-562b02086a91" target="id-616f25a9-5656-47dd-a0a4-e69c0532b230" xsi:type="Realization"/>
+    <relationship identifier="id-c3b800db-2b80-4248-9820-7d0443ea4cba" source="id-d94110fc-ff5c-488d-a115-562b02086a91" target="id-d7defcd1-0807-4544-9b70-1343cd2f42fa" xsi:type="Realization"/>
+    <relationship identifier="id-71a75662-a438-4ce7-b279-455d0c5007a4" source="id-d94110fc-ff5c-488d-a115-562b02086a91" target="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" xsi:type="Realization"/>
+    <relationship identifier="id-c6a28299-a721-43b4-879e-ef9e421aecb6" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="Realization"/>
+    <relationship identifier="id-ed8d9731-4199-401e-b5a0-a5fe753cc7f7" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Realization"/>
+    <relationship identifier="id-bc99b3ac-7ff0-40c5-aac9-1140ab4611f7" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-9c6344bc-55b8-48d3-8740-543c4f22b773" xsi:type="Realization"/>
+    <relationship identifier="id-70132bd5-c95b-4d7a-88e9-708f9c451b6f" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="Realization"/>
+    <relationship identifier="id-e822001b-df5e-4919-b4c0-0c4cb4c5ba6a" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-306f394a-2e02-4fd3-bb7e-8475e756652c" xsi:type="Realization"/>
+    <relationship identifier="id-71cb47b1-4eb4-48b9-8387-231849e58413" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" xsi:type="Realization"/>
+    <relationship identifier="id-05a169c7-1aba-4576-a2b2-5b8081a638b6" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" xsi:type="Realization"/>
+    <relationship identifier="id-110c951a-c293-4a21-a5b3-965a9b9d6f90" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" xsi:type="Realization"/>
+    <relationship identifier="id-f7cf772a-6925-4876-9f21-c6c900b1fc20" source="id-7beb1fa2-abae-499a-a762-d5d5249b53f8" target="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="Realization"/>
+    <relationship identifier="id-8b81efed-6721-42a6-950b-1fb6b6a50076" source="id-f632a587-c412-46bd-a387-17b8494b5700" target="id-3342d891-a82d-490a-846d-00b5a0074c1c" xsi:type="Realization"/>
+    <relationship identifier="id-bbcb5fa2-ace7-405a-b8df-da432d06b1a5" source="id-f632a587-c412-46bd-a387-17b8494b5700" target="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" xsi:type="Realization"/>
+    <relationship identifier="id-6e3fc527-086a-48a4-a17e-5c5120ac7663" source="id-8f7bb481-ccad-44be-833d-7a9889174c60" target="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" xsi:type="Realization"/>
+    <relationship identifier="id-688c69fa-9be6-4309-bde4-34a9a4a0f508" source="id-8f7bb481-ccad-44be-833d-7a9889174c60" target="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" xsi:type="Realization"/>
+    <relationship identifier="id-051a408f-071d-4ddf-9013-3206fbbd0f5f" source="id-8f7bb481-ccad-44be-833d-7a9889174c60" target="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" xsi:type="Realization"/>
+    <relationship identifier="id-54b7ef86-11e3-4c55-8bbd-243102afa77e" source="id-121a17d2-ac0c-4a5c-ad84-2549b485258f" target="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" xsi:type="Realization"/>
+    <relationship identifier="id-3bedafd9-32fc-4aef-b377-d6572eb4a031" source="id-121a17d2-ac0c-4a5c-ad84-2549b485258f" target="id-9f312eed-cd28-4dce-965f-9549b0b22b72" xsi:type="Realization"/>
+    <relationship identifier="id-3aae40bc-43dc-4afc-b11c-3d6a3700389c" source="id-e68a0e41-1593-42a1-9493-fa546f44bf4b" target="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" xsi:type="Realization"/>
+    <relationship identifier="id-097a7451-fd8f-463e-ac62-511dd2f7a9a6" source="id-e68a0e41-1593-42a1-9493-fa546f44bf4b" target="id-ddd07811-d0ae-4faa-b803-1f8c49e53fa1" xsi:type="Realization"/>
+    <relationship identifier="id-f2110d37-e5f0-447b-873a-8b5a0d54c1f2" source="id-4f439377-06ea-45ef-87b4-236ac48fa117" target="id-50092ca2-5580-4e16-b56f-c672e233b3e8" xsi:type="Realization"/>
+    <relationship identifier="id-fa8e3c84-c137-4bcc-9852-1a2504c346a8" source="id-a77f5aeb-6f21-422b-9aae-a59af175d0c6" target="id-ddd07811-d0ae-4faa-b803-1f8c49e53fa1" xsi:type="Realization"/>
+    <relationship identifier="id-dc0b6822-0102-44eb-9fa7-732ad623d3b4" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-76bc2f83-aebb-4fd3-bd50-75fe4f9bf134" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-3802d026-6f9e-467a-9d62-26de4de5a8f1" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-bd43b115-9b41-4ab5-8123-65b4b93912ac" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-06d5aaae-5c0b-40f9-8ebc-4cda84e8d6e1" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-8be35c02-6f49-43d0-85ca-e1ab647b7b52" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-6cd5ca58-2203-4ead-b63a-83735a8441c4" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-1dd8340d-92df-4f8f-8b13-b2a60ace0639" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-10056172-dc89-4f12-86f0-06c85613a7dc" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-020a3020-b667-4343-8f72-cb9180a982bc" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-6d6607d1-bf20-482d-81e5-f6a9dae2d479" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-287cdffc-7946-4a20-8362-9b1f04fbf884" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-adafdc29-1ca8-4c7d-a6d7-d4ccffab353d" source="id-9f312eed-cd28-4dce-965f-9549b0b22b72" target="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-c279014a-dde5-4b84-b378-9a35b06bf0b1" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-ae7c63ba-b24a-4b60-845a-2b379ed7c72a" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-dc4e26e8-d65d-439d-871a-eb84e4376cee" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-9f030ea2-fe84-4b5d-9f48-f2f08a7593a1" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-112b9c75-c52f-4b3b-b46d-23aa02d961c8" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-53a078f7-1137-46ff-b002-0b902467c6a9" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-6f860042-adea-4796-8398-a5e5a3c09b1a" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-260a83d0-276d-4c1b-8738-ea8c49dd63b7" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-d785531d-f09c-4737-9bf6-9e295219d745" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-eee4cb32-7f40-4a3c-92db-2d5126d4f495" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-1ff85e9d-ccf1-42e8-9630-20fda3c9daea" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-353547f6-e302-4dbd-9a84-c6c693b38901" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-c2498b0d-d836-4333-b087-caf19c89dc13" source="id-9c6344bc-55b8-48d3-8740-543c4f22b773" target="id-a2d9f3e0-7b09-4793-a26f-4531fae7c52f" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-98178f8a-4dc8-44c6-a1e7-023a86bfbbf1" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-a2d9f3e0-7b09-4793-a26f-4531fae7c52f" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-195bda88-225e-4731-97ac-5beb1f307662" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-a2d9f3e0-7b09-4793-a26f-4531fae7c52f" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-bc91fb2d-e2a8-413f-9aab-1a630c445071" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-a2d9f3e0-7b09-4793-a26f-4531fae7c52f" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-d985ce6c-881a-4c76-93c2-42756252c9f4" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-63789c6b-9e56-4428-a887-095a10757550" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-86db84af-6d26-4e56-aaab-88cbef21047b" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-63789c6b-9e56-4428-a887-095a10757550" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-a5b383db-7584-44db-b62e-24a90c3add95" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-63789c6b-9e56-4428-a887-095a10757550" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-69652236-daf9-4217-9c8d-02e1afc2621e" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-63789c6b-9e56-4428-a887-095a10757550" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-a701934c-04e3-462c-8ab7-b564a71fe9d0" source="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" target="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-25c505e6-b448-44de-bb85-51120a012740" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-733d807a-3973-438a-809e-3b78448865b9" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-cdc31841-0d6a-4978-9e02-ecedce54bb2e" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-7300c371-baac-4f3f-9e1d-4021a9e37691" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-da795988-d733-4e19-9130-aef42ed31dd0" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-9ac734e8-8dac-4683-9faf-e7904be69917" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-a8c0cbee-bcc0-49e9-8ec2-cfab09f95bbb" source="id-5a359712-886b-410c-a811-6a37d9728fad" target="id-2b2e913f-2e13-4cf5-9ea0-2ab73cf2394f" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-df810b9f-36a0-4a6b-a0cc-1eb513c47e24" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-2b2e913f-2e13-4cf5-9ea0-2ab73cf2394f" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-74388768-8c54-40b1-acaf-d024057bf9bd" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-2b2e913f-2e13-4cf5-9ea0-2ab73cf2394f" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-5d53fd69-6f45-44a3-9a60-ed8e4ad021c7" source="id-38608a00-6935-4cbb-b182-3e345311d32e" target="id-2b2e913f-2e13-4cf5-9ea0-2ab73cf2394f" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-b4c50453-739f-491e-9d95-c09fa73de0ef" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-7049951f-839a-4e43-aff4-cda57731b0e3" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-0525ba8a-effc-4179-b64c-a34a072dab8a" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-7049951f-839a-4e43-aff4-cda57731b0e3" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-f7fea897-33ac-40ee-966e-92669274dcf7" source="id-d7defcd1-0807-4544-9b70-1343cd2f42fa" target="id-7049951f-839a-4e43-aff4-cda57731b0e3" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-e0523211-a357-465b-8f85-837d11e485ef" source="id-cd6afa27-4621-405a-882a-1b059cab5b30" target="id-382a5d6a-6395-406d-afe3-4fb68de8da44" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-171d01ce-3ced-412c-a6f9-ffc88853603d" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-382a5d6a-6395-406d-afe3-4fb68de8da44" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-2fc0d41e-c3a8-45f2-9b49-ad66a3cb4ff5" source="id-dfd92e6a-82cc-4340-a5a6-3f07c9b96acf" target="id-382a5d6a-6395-406d-afe3-4fb68de8da44" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-f3452a92-7a1a-471b-a94c-2d4eaebac3a1" source="id-1dea16af-8743-455c-a0d2-940006778981" target="id-e62c70e4-bc6e-456f-85e2-687e2b1fc77e" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-58d553ff-a725-4dae-890c-e73498f1fe70" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-e62c70e4-bc6e-456f-85e2-687e2b1fc77e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-f44bddaa-bd58-434e-84d5-f946b997ae19" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-e62c70e4-bc6e-456f-85e2-687e2b1fc77e" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-d4dc4397-343b-4747-a04f-43d0fa7fb9db" source="id-732063e3-0f66-4ad6-8cc2-0cee2f87b5ee" target="id-3a9203d3-ae7b-4714-97d6-54d88f33ed7b" xsi:type="Access" accessType="Write">
+      <name xml:lang="en">system of record</name>
+    </relationship>
+    <relationship identifier="id-69df3e00-987a-424f-b66f-e62b6f93088a" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-3a9203d3-ae7b-4714-97d6-54d88f33ed7b" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-10c6270b-f572-45c2-ba5b-97910adc1079" source="id-e56a1711-cd55-483f-8c46-f52c420e0476" target="id-3a9203d3-ae7b-4714-97d6-54d88f33ed7b" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-4bd40ead-90dd-4ca3-a337-d3d0d5c446c3" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-3a9203d3-ae7b-4714-97d6-54d88f33ed7b" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-3665b13f-6ecc-492b-b5d6-3d69ad31a5a9" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-3a9203d3-ae7b-4714-97d6-54d88f33ed7b" xsi:type="Access" accessType="Read">
+      <name xml:lang="en">system of reference</name>
+    </relationship>
+    <relationship identifier="id-3bf40c35-9558-4273-b350-fcc99ec3d6f9" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-9f2c1dc0-e83b-43c7-acf7-9abf3799fe7b" xsi:type="Realization"/>
+    <relationship identifier="id-0911a19b-46e1-4e21-bea2-58f10dc24674" source="id-9f2c1dc0-e83b-43c7-acf7-9abf3799fe7b" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-7ce1bf42-69fb-45d9-9783-cc7c549b8695" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" xsi:type="Realization"/>
+    <relationship identifier="id-ef227d0e-2494-4aad-8792-695ab45bd9c6" source="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-e62db277-8686-49f6-8852-47df513c7d73" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-099b17e2-24b5-4163-a96f-18361e09e48f" xsi:type="Realization"/>
+    <relationship identifier="id-1e03c39a-d5fa-4596-9f5f-5a05ab1e4e30" source="id-099b17e2-24b5-4163-a96f-18361e09e48f" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-c1ec608f-d3ce-4a20-a663-a678ed97d2d6" source="id-9c6344bc-55b8-48d3-8740-543c4f22b773" target="id-becccb51-213c-4833-9d24-9c0cb9b33a08" xsi:type="Realization"/>
+    <relationship identifier="id-a015e5e6-708e-4771-899a-efd5a3369e0a" source="id-becccb51-213c-4833-9d24-9c0cb9b33a08" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-a80fdec4-c3cc-4c58-b059-247eae89eb62" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-53e14aff-b9f7-4722-b829-db82f872da1a" xsi:type="Realization"/>
+    <relationship identifier="id-3e2734c8-9b9f-440f-ae7c-645e4a0030da" source="id-53e14aff-b9f7-4722-b829-db82f872da1a" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-6cc075c8-27da-42f0-94e3-85971769ecbc" source="id-2d53a8b7-0a34-4809-9c21-f57b62636bc2" target="id-4c33bcfe-11a9-460b-ab46-f2791e4d3d79" xsi:type="Realization"/>
+    <relationship identifier="id-9d2ac456-fe41-430f-aadf-d41c1885294d" source="id-4c33bcfe-11a9-460b-ab46-f2791e4d3d79" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-5f0c3c23-571d-46b7-b31f-bc651bd825ae" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-873c5197-ce00-47bd-aa75-08276337ebfd" xsi:type="Realization"/>
+    <relationship identifier="id-2dead709-2e63-40ac-82ec-244fdc49e860" source="id-873c5197-ce00-47bd-aa75-08276337ebfd" target="id-e984780b-b690-4d09-b942-7da34ee6e60a" xsi:type="Access" accessType="Write"/>
+    <relationship identifier="id-73abf1fd-0d62-48e0-9dc6-82561eb9dd20" source="id-9f2c1dc0-e83b-43c7-acf7-9abf3799fe7b" target="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" xsi:type="Flow">
+      <name xml:lang="en">Order-to-Cash Flow: PawsPlus.com -&gt; Order Management System</name>
+    </relationship>
+    <relationship identifier="id-eaaff630-42f9-4fdc-9625-9b7821306701" source="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" target="id-099b17e2-24b5-4163-a96f-18361e09e48f" xsi:type="Flow">
+      <name xml:lang="en">Order-to-Cash Flow: Order Management System -&gt; Inventory Service</name>
+    </relationship>
+    <relationship identifier="id-af1e5945-bcd9-418a-aee6-9fe0af2b7a8b" source="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" target="id-becccb51-213c-4833-9d24-9c0cb9b33a08" xsi:type="Flow">
+      <name xml:lang="en">Order-to-Cash Flow: Order Management System -&gt; Payment Gateway</name>
+    </relationship>
+    <relationship identifier="id-0cd6af0b-1f5f-454f-a81f-050d81afb5eb" source="id-8518ac03-cf8f-4875-8b7f-c6706dcbb645" target="id-53e14aff-b9f7-4722-b829-db82f872da1a" xsi:type="Flow">
+      <name xml:lang="en">Order-to-Cash Flow: Order Management System -&gt; Warehouse Management System</name>
+    </relationship>
+    <relationship identifier="id-04c9b53d-f2f7-4e7b-836e-8e57b555e328" source="id-becccb51-213c-4833-9d24-9c0cb9b33a08" target="id-4c33bcfe-11a9-460b-ab46-f2791e4d3d79" xsi:type="Flow">
+      <name xml:lang="en">Order-to-Cash Flow: Payment Gateway -&gt; Settlement Engine</name>
+    </relationship>
+    <relationship identifier="id-e19954d7-d390-44a6-b21d-93e977758ee9" source="id-4c33bcfe-11a9-460b-ab46-f2791e4d3d79" target="id-873c5197-ce00-47bd-aa75-08276337ebfd" xsi:type="Flow">
+      <name xml:lang="en">Order-to-Cash Flow: Settlement Engine -&gt; SAP ERP</name>
+    </relationship>
+    <relationship identifier="id-82085a1f-4627-4e30-8bdd-5a98b328c0a8" source="id-d606f44f-cd3d-4454-8da4-6d5ba8990ac7" target="id-a8a0bc44-1b25-49b6-a730-6af2fc8f1b6a" xsi:type="Realization"/>
+    <relationship identifier="id-ad646932-c6d4-4328-9ae0-22f669d0a68f" source="id-a8a0bc44-1b25-49b6-a730-6af2fc8f1b6a" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-63a4de16-f92c-4576-865f-38699b8f5940" source="id-ca1575a1-f5e2-4de8-a9aa-f5f75a65a9e2" target="id-88df5fe5-5c6b-460d-ac13-d219ea108ff1" xsi:type="Realization"/>
+    <relationship identifier="id-c78ecb0b-3141-4374-a0c3-2736c142c231" source="id-88df5fe5-5c6b-460d-ac13-d219ea108ff1" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-ee5e0a97-7289-4f79-838b-5e7525030f66" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-12cbb986-58b9-4ded-98c8-55ccbfc9b0b5" xsi:type="Realization"/>
+    <relationship identifier="id-5abd58bb-f011-4793-85ab-19e68e6db543" source="id-12cbb986-58b9-4ded-98c8-55ccbfc9b0b5" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-e1e32a42-dcfb-42b4-af5a-4fac79f21f1e" source="id-50092ca2-5580-4e16-b56f-c672e233b3e8" target="id-7878cb41-2b1c-4955-99b9-62d02166531e" xsi:type="Realization"/>
+    <relationship identifier="id-32ea36eb-52f9-4d9a-920b-bb017070fff5" source="id-7878cb41-2b1c-4955-99b9-62d02166531e" target="id-c6a2118d-9373-48d0-94a7-5cb265d72f7e" xsi:type="Access" accessType="Write"/>
+    <relationship identifier="id-6a0bc9b5-1583-47e5-97f5-c518c53eb09e" source="id-a8a0bc44-1b25-49b6-a730-6af2fc8f1b6a" target="id-88df5fe5-5c6b-460d-ac13-d219ea108ff1" xsi:type="Flow">
+      <name xml:lang="en">Customer 360 Sync: Customer Hub -&gt; PawsPlus.com</name>
+    </relationship>
+    <relationship identifier="id-06f44e4d-14c1-48a1-b6e5-123bfe6c635e" source="id-a8a0bc44-1b25-49b6-a730-6af2fc8f1b6a" target="id-12cbb986-58b9-4ded-98c8-55ccbfc9b0b5" xsi:type="Flow">
+      <name xml:lang="en">Customer 360 Sync: Customer Hub -&gt; CommsPlatform</name>
+    </relationship>
+    <relationship identifier="id-49e48e6a-58a8-4ab6-83d7-c823535facfd" source="id-a8a0bc44-1b25-49b6-a730-6af2fc8f1b6a" target="id-7878cb41-2b1c-4955-99b9-62d02166531e" xsi:type="Flow">
+      <name xml:lang="en">Customer 360 Sync: Customer Hub -&gt; Enterprise Data Warehouse</name>
+    </relationship>
+    <relationship identifier="id-4e125d6a-af8b-4ed3-9f50-685079069dab" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-fd61d8f6-02f8-4575-a31b-dc3c2aad067b" xsi:type="Realization"/>
+    <relationship identifier="id-21034ffe-887e-4fda-ae4a-ab7b949b5a55" source="id-fd61d8f6-02f8-4575-a31b-dc3c2aad067b" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-48a0af02-eab1-4a94-a8be-c1ec342591cc" source="id-0a428c87-f4ed-4a38-9c46-a211aef419e1" target="id-297950e1-0e3f-40af-afe8-a4af11b3c50b" xsi:type="Realization"/>
+    <relationship identifier="id-6ffb2f40-8f5b-4e5d-ad6a-bf2561e672fe" source="id-297950e1-0e3f-40af-afe8-a4af11b3c50b" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-3fe0b3b8-42c8-4017-8ef5-eafac4b0c06a" source="id-d2228401-402d-4814-a860-9d9f3f762460" target="id-2763ea0a-563d-43bc-956b-4d58c43e913a" xsi:type="Realization"/>
+    <relationship identifier="id-3eeff699-b009-4015-8a9a-f7f7b9478329" source="id-2763ea0a-563d-43bc-956b-4d58c43e913a" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-35a65afa-efa0-42b9-ac68-09911b5ea68f" source="id-616f25a9-5656-47dd-a0a4-e69c0532b230" target="id-bcb0fbce-a0de-4590-a066-79e01b364eb1" xsi:type="Realization"/>
+    <relationship identifier="id-dab08fff-5844-437d-bd59-8cae69551cc8" source="id-bcb0fbce-a0de-4590-a066-79e01b364eb1" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-7c1f98fd-a321-4373-862f-35ba6f6b533f" source="id-5a359712-886b-410c-a811-6a37d9728fad" target="id-0b1b08a4-3034-4231-86bf-7464b2f613f9" xsi:type="Realization"/>
+    <relationship identifier="id-abb81222-8c7f-4f99-9ad8-9362da02d59b" source="id-0b1b08a4-3034-4231-86bf-7464b2f613f9" target="id-90f79316-3dab-40ed-b2a8-2d26f9491e1e" xsi:type="Access" accessType="Write"/>
+    <relationship identifier="id-883e19fa-d2f6-4389-9f13-e2ad35d34a66" source="id-fd61d8f6-02f8-4575-a31b-dc3c2aad067b" target="id-297950e1-0e3f-40af-afe8-a4af11b3c50b" xsi:type="Flow">
+      <name xml:lang="en">Inventory Replenishment Cycle: Warehouse Management System -&gt; Inventory Service</name>
+    </relationship>
+    <relationship identifier="id-7264fc35-2746-4965-bab8-40e56ac1dc12" source="id-297950e1-0e3f-40af-afe8-a4af11b3c50b" target="id-2763ea0a-563d-43bc-956b-4d58c43e913a" xsi:type="Flow">
+      <name xml:lang="en">Inventory Replenishment Cycle: Inventory Service -&gt; Demand Planner</name>
+    </relationship>
+    <relationship identifier="id-9dc7ee1f-cbd4-4627-90c7-7882ab9d14dd" source="id-2763ea0a-563d-43bc-956b-4d58c43e913a" target="id-bcb0fbce-a0de-4590-a066-79e01b364eb1" xsi:type="Flow">
+      <name xml:lang="en">Inventory Replenishment Cycle: Demand Planner -&gt; SAP ERP</name>
+    </relationship>
+    <relationship identifier="id-21383af6-bd1f-404f-ba4e-55b3f41aede3" source="id-bcb0fbce-a0de-4590-a066-79e01b364eb1" target="id-0b1b08a4-3034-4231-86bf-7464b2f613f9" xsi:type="Flow">
+      <name xml:lang="en">Inventory Replenishment Cycle: SAP ERP -&gt; Vendor Portal</name>
+    </relationship>
+    <relationship identifier="id-339d728e-0be2-4eb8-b154-78dd1686441e" source="id-145da100-c5fc-48ec-9547-5cf4fe5f7ec1" target="id-73c2fa13-b96f-40fd-99f8-dc6ad4af223c" xsi:type="Realization"/>
+    <relationship identifier="id-ef7fd28f-5691-4caf-85be-58ccc3865ded" source="id-73c2fa13-b96f-40fd-99f8-dc6ad4af223c" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="Write"/>
+    <relationship identifier="id-2b1e66b7-6477-4302-92bc-f5ca5a5d8923" source="id-9c6344bc-55b8-48d3-8740-543c4f22b773" target="id-8be750d5-0db1-4f1b-9eb4-6f1ce46949e2" xsi:type="Realization"/>
+    <relationship identifier="id-22082872-7b46-4715-90e5-ca84b6bcc979" source="id-8be750d5-0db1-4f1b-9eb4-6f1ce46949e2" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-3327cd6b-0a28-49ea-adc5-63d453c0df7b" source="id-a0b124d1-9db4-4c1c-b855-a84433f4c9dd" target="id-458b3a66-3547-4368-b37f-f374fb5d1720" xsi:type="Realization"/>
+    <relationship identifier="id-778bcbcd-ce95-48e0-a9c2-56c0d3a883c3" source="id-458b3a66-3547-4368-b37f-f374fb5d1720" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-b188c20a-c4f7-400c-91ed-b25e30028d7d" source="id-fc9dd6ce-b64e-4157-a5ba-046b7bcf906b" target="id-335e9178-fbd7-47ea-924e-cd64422bf542" xsi:type="Realization"/>
+    <relationship identifier="id-54a083c5-02a9-4a79-a10d-d89422174b00" source="id-335e9178-fbd7-47ea-924e-cd64422bf542" target="id-5a0b9767-efbb-4f78-962f-41e7eb74e565" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-91a4fcae-d6a8-4226-8ce1-5020040ae480" source="id-73c2fa13-b96f-40fd-99f8-dc6ad4af223c" target="id-8be750d5-0db1-4f1b-9eb4-6f1ce46949e2" xsi:type="Flow">
+      <name xml:lang="en">Subscription Autoship Pipeline: PawsCare+ Platform -&gt; Payment Gateway</name>
+    </relationship>
+    <relationship identifier="id-df521643-7288-4da0-837e-6075b6f84a00" source="id-73c2fa13-b96f-40fd-99f8-dc6ad4af223c" target="id-458b3a66-3547-4368-b37f-f374fb5d1720" xsi:type="Flow">
+      <name xml:lang="en">Subscription Autoship Pipeline: PawsCare+ Platform -&gt; Order Management System</name>
+    </relationship>
+    <relationship identifier="id-98f4f947-5e80-4184-a134-9064ed66e970" source="id-458b3a66-3547-4368-b37f-f374fb5d1720" target="id-335e9178-fbd7-47ea-924e-cd64422bf542" xsi:type="Flow">
+      <name xml:lang="en">Subscription Autoship Pipeline: Order Management System -&gt; Warehouse Management System</name>
+    </relationship>
+    <relationship identifier="id-7603f535-8ba4-479a-bef3-b7eefb802c0b" source="id-63a4bcbf-6082-4d72-a7f9-aa786c0b312d" target="id-c4c380b7-a6c3-4721-a71f-237c8dec75d0" xsi:type="Realization"/>
+    <relationship identifier="id-733edfef-6d0c-4033-b4a6-4a1be942cba3" source="id-c4c380b7-a6c3-4721-a71f-237c8dec75d0" target="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-acf11f8a-0a74-4627-bdad-05df8480a3d7" source="id-5f0ac898-d0bf-4f73-bbb9-2324fa8ff1e4" target="id-28d7d045-acc0-4bee-a842-11037e657682" xsi:type="Realization"/>
+    <relationship identifier="id-be5c69be-001f-4b27-955a-da8b35aaef02" source="id-28d7d045-acc0-4bee-a842-11037e657682" target="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="Access" accessType="ReadWrite"/>
+    <relationship identifier="id-e5ac3a54-b607-4a4d-9587-914ec13f04d4" source="id-306f394a-2e02-4fd3-bb7e-8475e756652c" target="id-54baed9b-e27b-459d-b57f-da7b5935e6f9" xsi:type="Realization"/>
+    <relationship identifier="id-750e2484-7a04-44c4-9519-c5738768d675" source="id-54baed9b-e27b-459d-b57f-da7b5935e6f9" target="id-fae28e3d-5288-4ea0-ad71-3c405fbef4a5" xsi:type="Access" accessType="Write"/>
+    <relationship identifier="id-b78cc735-d7fe-44da-8cf6-6a073285a96c" source="id-c4c380b7-a6c3-4721-a71f-237c8dec75d0" target="id-28d7d045-acc0-4bee-a842-11037e657682" xsi:type="Flow">
+      <name xml:lang="en">Prescription Fulfillment Flow: VetConnect -&gt; RxManager</name>
+    </relationship>
+    <relationship identifier="id-a3ef1f25-dfdd-4e6d-b164-55fa308794ae" source="id-28d7d045-acc0-4bee-a842-11037e657682" target="id-54baed9b-e27b-459d-b57f-da7b5935e6f9" xsi:type="Flow">
+      <name xml:lang="en">Prescription Fulfillment Flow: RxManager -&gt; CommsPlatform</name>
+    </relationship>
+  </relationships>
   <propertyDefinitions>
+    <propertyDefinition identifier="propdef-specialization" type="string">
+      <name xml:lang="en">specialization</name>
+    </propertyDefinition>
     <propertyDefinition identifier="propdef-ApplicationComponent-lifecycle_status" type="string">
       <name xml:lang="en">lifecycle_status</name>
     </propertyDefinition>
-    <propertyDefinition identifier="propdef-ApplicationComponent-fitness_score" type="real">
+    <propertyDefinition identifier="propdef-ApplicationComponent-fitness_score" type="number">
       <name xml:lang="en">fitness_score</name>
     </propertyDefinition>
-    <propertyDefinition identifier="propdef-ApplicationComponent-annual_tco" type="real">
+    <propertyDefinition identifier="propdef-ApplicationComponent-annual_tco" type="number">
       <name xml:lang="en">annual_tco</name>
     </propertyDefinition>
     <propertyDefinition identifier="propdef-ApplicationComponent-owning_team" type="string">
@@ -23,10 +2846,10 @@
     <propertyDefinition identifier="propdef-ApplicationInterface-protocol" type="string">
       <name xml:lang="en">protocol</name>
     </propertyDefinition>
-    <propertyDefinition identifier="propdef-ApplicationInterface-avg_daily_volume" type="real">
+    <propertyDefinition identifier="propdef-ApplicationInterface-avg_daily_volume" type="number">
       <name xml:lang="en">avg_daily_volume</name>
     </propertyDefinition>
-    <propertyDefinition identifier="propdef-ApplicationInterface-sla_ms" type="real">
+    <propertyDefinition identifier="propdef-ApplicationInterface-sla_ms" type="number">
       <name xml:lang="en">sla_ms</name>
     </propertyDefinition>
     <propertyDefinition identifier="propdef-ApplicationService-criticality_tier" type="string">
@@ -50,7 +2873,7 @@
     <propertyDefinition identifier="propdef-SystemSoftware-end_of_support" type="string">
       <name xml:lang="en">end_of_support</name>
     </propertyDefinition>
-    <propertyDefinition identifier="propdef-SystemSoftware-license_cost_annual" type="real">
+    <propertyDefinition identifier="propdef-SystemSoftware-license_cost_annual" type="number">
       <name xml:lang="en">license_cost_annual</name>
     </propertyDefinition>
     <propertyDefinition identifier="propdef-SystemSoftware-standardization_status" type="string">
@@ -62,2678 +2885,14 @@
     <propertyDefinition identifier="propdef-DataObject-classification" type="string">
       <name xml:lang="en">classification</name>
     </propertyDefinition>
-    <propertyDefinition identifier="propdef-DataObject-quality_score" type="real">
+    <propertyDefinition identifier="propdef-DataObject-quality_score" type="number">
       <name xml:lang="en">quality_score</name>
     </propertyDefinition>
     <propertyDefinition identifier="propdef-ApplicationProcess-transformation_type" type="string">
       <name xml:lang="en">transformation_type</name>
     </propertyDefinition>
+    <propertyDefinition identifier="propdef-DataObject-contains_pii" type="string">
+      <name xml:lang="en">contains_pii</name>
+    </propertyDefinition>
   </propertyDefinitions>
-  <elements>
-    <element identifier="id-5147ffff-7e3c-4446-9171-edc14ff6b4f1" xsi:type="Capability">
-      <name xml:lang="en">Customer Management</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">established</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">invest</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ed46fa05-a02c-480b-bca7-66e6c775fd95" xsi:type="Capability">
-      <name xml:lang="en">Customer Onboarding</name>
-    </element>
-    <element identifier="id-b17a00bd-e844-421f-a562-385dcfc25951" xsi:type="Capability">
-      <name xml:lang="en">Customer Identity &amp; Profile</name>
-    </element>
-    <element identifier="id-38550322-65f8-4776-846c-f5f4dfb5c8f1" xsi:type="Capability">
-      <name xml:lang="en">Loyalty &amp; Rewards</name>
-    </element>
-    <element identifier="id-48524bca-869b-458c-8db9-4bd9de01cf93" xsi:type="Capability">
-      <name xml:lang="en">Customer Communication</name>
-    </element>
-    <element identifier="id-57c73787-fba0-425a-a786-6cc51727a6fa" xsi:type="Capability">
-      <name xml:lang="en">Commerce</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">established</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">invest</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-fe1e4ecf-9463-42d5-a791-8847265426fc" xsi:type="Capability">
-      <name xml:lang="en">Online Ordering</name>
-    </element>
-    <element identifier="id-9762bbaf-d87a-427c-b1a3-b705dea78c23" xsi:type="Capability">
-      <name xml:lang="en">In-Store Point of Sale</name>
-    </element>
-    <element identifier="id-7ced6d94-cffd-4f54-b7f0-8463450a1393" xsi:type="Capability">
-      <name xml:lang="en">Marketplace Management</name>
-    </element>
-    <element identifier="id-a003a667-c4fa-45ba-ad32-87243f9dbe9d" xsi:type="Capability">
-      <name xml:lang="en">Pricing &amp; Promotions</name>
-    </element>
-    <element identifier="id-5eaf4331-076d-49a0-9beb-64a0a30d4cef" xsi:type="Capability">
-      <name xml:lang="en">Cart &amp; Checkout</name>
-    </element>
-    <element identifier="id-a5bca47b-1c91-49c5-855d-6fc340e32e4b" xsi:type="Capability">
-      <name xml:lang="en">Product Management</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">established</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">maintain</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-235be7c0-8eb8-478f-8472-024658d663bd" xsi:type="Capability">
-      <name xml:lang="en">Product Catalog</name>
-    </element>
-    <element identifier="id-42986414-b483-4df0-9558-6836852d8bed" xsi:type="Capability">
-      <name xml:lang="en">Product Sourcing</name>
-    </element>
-    <element identifier="id-0f5c40b0-fd27-4788-b0ef-cffc2f5a74fc" xsi:type="Capability">
-      <name xml:lang="en">Vendor Management</name>
-    </element>
-    <element identifier="id-17c38a8d-43ae-4014-9ba1-1b640e90197e" xsi:type="Capability">
-      <name xml:lang="en">Inventory &amp; Fulfillment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">emerging</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">invest</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-62aeb9e5-adbc-49cd-b4ec-9a34d126ff02" xsi:type="Capability">
-      <name xml:lang="en">Inventory Management</name>
-    </element>
-    <element identifier="id-8bdf2109-02af-4571-8d28-c74c90795171" xsi:type="Capability">
-      <name xml:lang="en">Warehouse Operations</name>
-    </element>
-    <element identifier="id-cd693def-f34e-48d2-a7e2-f15fa93ee5af" xsi:type="Capability">
-      <name xml:lang="en">Order Fulfillment</name>
-    </element>
-    <element identifier="id-e0d0162c-6978-45ce-93a8-d8dc40c261eb" xsi:type="Capability">
-      <name xml:lang="en">Ship-from-Store</name>
-    </element>
-    <element identifier="id-85e1708b-21d0-48f4-aa8a-7a78736c70a4" xsi:type="Capability">
-      <name xml:lang="en">Returns Processing</name>
-    </element>
-    <element identifier="id-d20dc5c5-483a-4f4d-8721-0b40e7123c21" xsi:type="Capability">
-      <name xml:lang="en">Payment Processing</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">established</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">maintain</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b5b893b0-baaa-43f9-bdd6-75da165124e3" xsi:type="Capability">
-      <name xml:lang="en">Payment Authorization</name>
-    </element>
-    <element identifier="id-83ec0e6e-49ce-4dc8-b46d-8e0f43131190" xsi:type="Capability">
-      <name xml:lang="en">Payment Settlement</name>
-    </element>
-    <element identifier="id-f39adccd-f2aa-4d0f-8483-b1896eec326f" xsi:type="Capability">
-      <name xml:lang="en">Refund Processing</name>
-    </element>
-    <element identifier="id-86ec6dea-edf3-41a3-8154-2f85c008b8e3" xsi:type="Capability">
-      <name xml:lang="en">Supply Chain</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">established</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">maintain</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-456ac6f0-b4fa-46b2-9312-ff1ca17c7c1a" xsi:type="Capability">
-      <name xml:lang="en">Demand Forecasting</name>
-    </element>
-    <element identifier="id-b92544bb-08c9-4c14-9c47-1229295daa21" xsi:type="Capability">
-      <name xml:lang="en">Purchase Order Management</name>
-    </element>
-    <element identifier="id-220b13a4-771a-4695-ac89-5a905b300013" xsi:type="Capability">
-      <name xml:lang="en">Supplier Logistics</name>
-    </element>
-    <element identifier="id-9fc498b7-6079-4aaf-92cb-a62b621bcfd3" xsi:type="Capability">
-      <name xml:lang="en">Veterinary Services</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">emerging</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">invest</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-66d7da84-426e-4203-bad1-c6ee5e7b1dd1" xsi:type="Capability">
-      <name xml:lang="en">Clinic Appointment Scheduling</name>
-    </element>
-    <element identifier="id-c388a7d0-a5fe-4479-a28f-aafc511264c7" xsi:type="Capability">
-      <name xml:lang="en">Pet Health Records</name>
-    </element>
-    <element identifier="id-cd79427f-7326-40ae-9684-955213811065" xsi:type="Capability">
-      <name xml:lang="en">Prescription Management</name>
-    </element>
-    <element identifier="id-f68129f4-5d47-406a-9fb7-f6620379aef4" xsi:type="Capability">
-      <name xml:lang="en">Subscription &amp; Wellness</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">emerging</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">invest</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-fe726c6b-2bbf-4fbd-846e-a8971dcb82dd" xsi:type="Capability">
-      <name xml:lang="en">Subscription Lifecycle</name>
-    </element>
-    <element identifier="id-5b38a060-0f46-4256-8e29-f6ad5b4fc16a" xsi:type="Capability">
-      <name xml:lang="en">Autoship Management</name>
-    </element>
-    <element identifier="id-71f39497-5e53-4731-b613-9eb5e7198622" xsi:type="Capability">
-      <name xml:lang="en">Wellness Plan Administration</name>
-    </element>
-    <element identifier="id-08dcd9b6-17aa-433b-9ec9-2cc4d3a5a343" xsi:type="Capability">
-      <name xml:lang="en">Corporate Operations</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">established</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">maintain</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-8107c641-e85c-4289-adae-33d968da3b4f" xsi:type="Capability">
-      <name xml:lang="en">Financial Management</name>
-    </element>
-    <element identifier="id-a115c0d9-e6e1-49db-acd2-d9c218950dc8" xsi:type="Capability">
-      <name xml:lang="en">Human Resources</name>
-    </element>
-    <element identifier="id-9e3082e2-8452-4f9b-aa55-2ad3781bdc15" xsi:type="Capability">
-      <name xml:lang="en">Store Operations</name>
-    </element>
-    <element identifier="id-a26c4ac3-6f47-40a0-ae38-98f9a636e492" xsi:type="Capability">
-      <name xml:lang="en">Analytics &amp; Insights</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Capability-maturity">
-          <value xml:lang="en">emerging</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Capability-strategic_priority">
-          <value xml:lang="en">invest</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f3d69b91-b4b4-414d-a20a-3b4e2922413f" xsi:type="Capability">
-      <name xml:lang="en">Business Intelligence</name>
-    </element>
-    <element identifier="id-f1a0ca2d-c842-4b78-941f-1e825a12304b" xsi:type="Capability">
-      <name xml:lang="en">Customer Analytics</name>
-    </element>
-    <element identifier="id-6728ab07-3d40-47ee-b829-ae7c88073c47" xsi:type="Capability">
-      <name xml:lang="en">Demand Analytics</name>
-    </element>
-    <element identifier="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" xsi:type="ApplicationComponent">
-      <name xml:lang="en">PawsPlus.com</name>
-      <documentation xml:lang="en">E-commerce web and mobile platform</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.3</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">1800000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" xsi:type="ApplicationComponent">
-      <name xml:lang="en">StoreOS POS</name>
-      <documentation xml:lang="en">In-store point of sale terminals and kiosks</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.8</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">950000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Store Technology</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Loyalty Engine</name>
-      <documentation xml:lang="en">Points, tiers, and rewards management</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">320000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Customer Experience</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-9982a44e-9401-49c4-8476-47d813981582" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Promo Manager</name>
-      <documentation xml:lang="en">Pricing rules, promotions, and coupon management</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.5</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">280000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Merchandising Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Customer Hub</name>
-      <documentation xml:lang="en">Customer identity, profile, and preferences (CDP)</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.5</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">650000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Customer Experience</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" xsi:type="ApplicationComponent">
-      <name xml:lang="en">CommsPlatform</name>
-      <documentation xml:lang="en">Email, SMS, push notification orchestration</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">420000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Customer Experience</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-96325512-2329-4979-bffc-cd98fe460f5f" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Product Information Manager</name>
-      <documentation xml:lang="en">Product catalog, attributes, images, and taxonomy</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">380000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Merchandising Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-69217365-f468-43e6-a560-80a7b51fb83a" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Vendor Portal</name>
-      <documentation xml:lang="en">Supplier onboarding, compliance, and communication</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">190000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Supply Chain Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Inventory Service</name>
-      <documentation xml:lang="en">Real-time inventory positions across all channels</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.4</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">720000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Warehouse Management System</name>
-      <documentation xml:lang="en">DC operations, pick/pack/ship</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.6</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">1100000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Order Management System</name>
-      <documentation xml:lang="en">Order lifecycle, routing, and orchestration</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">890000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ab63e507-eb74-4d4f-aea3-fee26ca3c331" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Legacy Returns Processor</name>
-      <documentation xml:lang="en">Returns authorization and restocking (mainframe-based)</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">sunset</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">1.8</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">450000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-73956421-5166-4390-8d3d-47cd1d27d7f9" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Payment Gateway</name>
-      <documentation xml:lang="en">Card authorization, tokenization, and fraud screening</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.6</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">580000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Payments</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Settlement Engine</name>
-      <documentation xml:lang="en">End-of-day batch settlement and reconciliation</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.4</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">310000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Payments</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-6da69574-e14e-4505-a320-3b086578f026" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Demand Planner</name>
-      <documentation xml:lang="en">ML-based demand forecasting and replenishment</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.9</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">480000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Supply Chain Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-5489d56e-e12e-4a11-8211-49698a4cd712" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Supplier Logistics Hub</name>
-      <documentation xml:lang="en">Inbound logistics, ASN tracking, dock scheduling</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">260000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Supply Chain Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" xsi:type="ApplicationComponent">
-      <name xml:lang="en">VetConnect</name>
-      <documentation xml:lang="en">Clinic scheduling, partner integration, telehealth</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.7</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">520000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Vet Services Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-cfda2874-f06f-4483-be75-828739e80a01" xsi:type="ApplicationComponent">
-      <name xml:lang="en">RxManager</name>
-      <documentation xml:lang="en">Pet prescription management and pharmacy integration</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.3</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">340000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Vet Services Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" xsi:type="ApplicationComponent">
-      <name xml:lang="en">PawsCare+ Platform</name>
-      <documentation xml:lang="en">Subscription management, autoship, wellness plans</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">680000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Subscription Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" xsi:type="ApplicationComponent">
-      <name xml:lang="en">SAP ERP</name>
-      <documentation xml:lang="en">Finance, GL, AP/AR, fixed assets</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">2200000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Enterprise Systems</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ab39822b-d3cf-45fc-9c77-af528b94cab5" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Workday HCM</name>
-      <documentation xml:lang="en">HR, payroll, talent management</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">890000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Enterprise Systems</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-c5fa176f-ca05-4980-b55f-95def95ac15a" xsi:type="ApplicationComponent">
-      <name xml:lang="en">StoreOps Dashboard</name>
-      <documentation xml:lang="en">Store performance, staffing, and task management</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">3.5</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">210000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Store Technology</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Enterprise Data Warehouse</name>
-      <documentation xml:lang="en">Snowflake-based analytical data store</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.3</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">960000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Data Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-04ae0636-f529-45b4-9434-baa2a526c760" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Analytics Portal</name>
-      <documentation xml:lang="en">Tableau-based dashboards and self-service analytics</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">active</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">4.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">350000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Data Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-cee73b55-c5e1-40d9-9f1d-de928bb317dc" xsi:type="ApplicationComponent">
-      <name xml:lang="en">Legacy Reporting DB</name>
-      <documentation xml:lang="en">Oracle-based reporting database (being migrated to EDW)</documentation>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-lifecycle_status">
-          <value xml:lang="en">sunset</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-fitness_score">
-          <value xml:lang="en">2.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-annual_tco">
-          <value xml:lang="en">380000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationComponent-owning_team">
-          <value xml:lang="en">Data Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-2259bc59-3fbc-4309-947d-1231c49c0888" xsi:type="ApplicationService">
-      <name xml:lang="en">Submit Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-fde2a29c-43f2-4d6e-bd09-38c52265c985" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v2/orders</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">35000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">500.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f6903c90-c9f9-4b73-b50a-b1e73bd38eed" xsi:type="ApplicationService">
-      <name xml:lang="en">Customer Lookup</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-e09d8178-1bf8-4e4a-884b-6078c48803f1" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">GET /v1/customers/{id}</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">280000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">100.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-24b4dbda-2153-4b68-8c03-0d3465d30c71" xsi:type="ApplicationService">
-      <name xml:lang="en">Product Search</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-eb257e1f-d01f-44d8-ae5e-fea874936ef3" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">GET /v2/products/search</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">1200000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">150.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b27ab851-e4f6-41d2-8f70-bc072a1aaae1" xsi:type="ApplicationService">
-      <name xml:lang="en">Check Availability</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-18b703c8-6b1d-4e51-9e20-94f4bb707664" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">GET /v1/inventory/availability</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">950000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">200.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-013151d1-a14a-48e7-9094-9a7fa5ec9993" xsi:type="ApplicationService">
-      <name xml:lang="en">Process Payment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-dfb3df94-9c4c-4ce2-8bb2-fdb1453a1fd0" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v2/charges</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">35000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-663dc6e1-c588-4ca9-aff1-c6c62a2a3373" xsi:type="ApplicationService">
-      <name xml:lang="en">Apply Rewards</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-8ee38b61-7e47-43c3-adf9-959626de07d3" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/rewards/apply</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">22000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">200.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-21830b4c-49a6-42ad-993f-6ede4d98ae29" xsi:type="ApplicationService">
-      <name xml:lang="en">Evaluate Promotions</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Digital Commerce</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-e42a3837-e677-456a-94c6-58016c7b328e" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/promotions/evaluate</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">450000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">100.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d46357fc-8e26-4004-b9d5-24cd2dc41bbd" xsi:type="ApplicationService">
-      <name xml:lang="en">Process Payment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Store Technology</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-1f4e0852-ee46-44b0-9416-c51da0135aaa" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v2/charges</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">120000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-069b55e0-f5dc-425f-a807-1d59d982e885" xsi:type="ApplicationService">
-      <name xml:lang="en">Reserve Inventory</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Store Technology</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-5f9194d3-45b3-40d7-8fb7-57ce416ea087" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/inventory/reserve</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">120000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">200.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-66f4f6fa-1320-4736-b75d-c94e2ccbf94e" xsi:type="ApplicationService">
-      <name xml:lang="en">Redeem Points</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Store Technology</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-bd23f2ce-59e2-4b49-8c65-3326fc3f23ea" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/rewards/redeem</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">45000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">200.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-c217519f-9434-444e-a64e-22098ae58871" xsi:type="ApplicationService">
-      <name xml:lang="en">Allocate Inventory</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-344ef3ce-df0a-4d55-b6b4-3add955d6df2" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/inventory/allocate</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">40000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-acad5719-2942-4cd1-810b-ac5c0a91fd73" xsi:type="ApplicationService">
-      <name xml:lang="en">Create Shipment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-884e033a-68e5-4e6a-b649-309078520a9c" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">orders.routed (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">38000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">5000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-e87291e3-4dbd-43ca-8e7d-af323f5ee8a4" xsi:type="ApplicationService">
-      <name xml:lang="en">Order Notification</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b48d5eaf-cefd-4386-b952-417304392ac8" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">notifications.order (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">40000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">30000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-467dc55c-ff36-47d4-b4ed-96056fba3f21" xsi:type="ApplicationService">
-      <name xml:lang="en">Authorize Return</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-248d9a71-97b4-427b-9150-57cbbf04ac96" xsi:type="ApplicationInterface" specialization="MQ">
-      <name xml:lang="en">RETURNS.AUTH.REQ (MQ)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">MQ</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">3500.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">10000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4f55033f-9231-40fd-a661-89bacbfd7167" xsi:type="ApplicationService">
-      <name xml:lang="en">Settlement Batch</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Payments</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-42ad9d64-6de8-48bd-9364-e03af8a3c70a" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">payments.authorized (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">155000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">60000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-1d8d35aa-0b70-4a81-b79c-ae917c0acba4" xsi:type="ApplicationService">
-      <name xml:lang="en">Post Journal Entry</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Payments</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4fcae0d6-f003-48d1-8ba4-057059f6f6ff" xsi:type="ApplicationInterface" specialization="SFTP">
-      <name xml:lang="en">SETTLEMENT.SFTP</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">SFTP</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">1.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">3600000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b8bdfe19-33ba-4fff-8702-12472e2d8081" xsi:type="ApplicationService">
-      <name xml:lang="en">Inventory Snapshot</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-2047f33c-0e88-423a-8e5e-a47bc36efd14" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">inventory.snapshot (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">150.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">60000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-fbdf79a5-dc93-4976-8bab-4fc039a27565" xsi:type="ApplicationService">
-      <name xml:lang="en">Stock Update</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-5ecf051b-cb5c-482e-8ce9-a14f165bbfcb" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">inventory.adjustments (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">85000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">5000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4ea62834-30b4-46e1-ae1f-f707a70e158e" xsi:type="ApplicationService">
-      <name xml:lang="en">Create Purchase Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Supply Chain Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-67698cac-a6bc-492f-bc51-fbd94958298d" xsi:type="ApplicationInterface" specialization="SOAP">
-      <name xml:lang="en">RFC/BAPI MM.PO.CREATE</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">SOAP</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">200.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">5000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-5f7fe9d8-03e2-4c94-8a85-09bc4c3619ad" xsi:type="ApplicationService">
-      <name xml:lang="en">ASN Notification</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Supply Chain Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4e37222c-009f-4d25-983e-407ce032bf76" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/asn</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">500.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">2000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-230a77e5-0042-445d-9e3b-ef1966c13c0f" xsi:type="ApplicationService">
-      <name xml:lang="en">Inbound Receipt</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Supply Chain Tech</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-c4ad7f06-9b82-49bc-a1af-c6e05fbc6c92" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">receiving.inbound (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">500.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">30000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-97317099-f839-4d4c-9439-4f50129fcb12" xsi:type="ApplicationService">
-      <name xml:lang="en">Link Pet to Customer</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Vet Services Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-9241c699-edb4-4562-a222-0a4b96982645" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/customers/{id}/pets</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">2500.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">500.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-698607a7-b0d9-4ad0-9e00-7e46286ff3fe" xsi:type="ApplicationService">
-      <name xml:lang="en">Create Prescription</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Vet Services Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-9043a34f-20e1-458d-a1bd-1ae3191735d6" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v1/prescriptions</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">1800.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">500.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ef59bddb-7cfb-4665-bafd-3ae1227fefe3" xsi:type="ApplicationService">
-      <name xml:lang="en">Create Autoship Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Subscription Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d71241b0-9369-4aaf-a201-e210d422bd26" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v2/orders</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">12000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">500.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-1c89eac6-a089-495f-b495-e19852777a08" xsi:type="ApplicationService">
-      <name xml:lang="en">Recurring Charge</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Subscription Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f5d5fe1c-0a4a-4c43-a855-77161dbbbb86" xsi:type="ApplicationInterface" specialization="REST">
-      <name xml:lang="en">POST /v2/charges/recurring</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">REST</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">12000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-af166859-ee32-4496-9266-17eaf967d444" xsi:type="ApplicationService">
-      <name xml:lang="en">Subscription Notification</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Subscription Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-fd1a9e91-1e5b-4a67-a37d-5f7ab1c4ff45" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">notifications.subscription (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">15000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">30000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0794a1bb-59be-4070-a5ad-b1e7b9d0ee35" xsi:type="ApplicationService">
-      <name xml:lang="en">Prescription Ready Notification</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Vet Services Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ff8e545c-10bb-4dd9-a993-0827c1b78ac1" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">notifications.rx (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">1800.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">30000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-83434bde-ea53-4942-93f7-626809444268" xsi:type="ApplicationService">
-      <name xml:lang="en">Order Events Feed</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d0ebb5bc-56aa-4360-a170-149c020d7067" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">orders.completed (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">35000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d3cdd3bb-eaa9-42d1-a51f-55818da5a92f" xsi:type="ApplicationService">
-      <name xml:lang="en">Customer Profile Sync</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Customer Experience</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-7313af28-0841-4c04-a9e5-d3a977b2dc77" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">customers.updated (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">50000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d86709f2-7ac9-4971-a1d2-73d35dabd602" xsi:type="ApplicationService">
-      <name xml:lang="en">Inventory Events Feed</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier3</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Fulfillment Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-db13b01b-1483-4c64-87ca-5f055ea9e514" xsi:type="ApplicationInterface" specialization="Kafka">
-      <name xml:lang="en">inventory.changes (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">Kafka</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">200000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">300000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f2906ff2-7622-4f93-ad84-201dc18df7cc" xsi:type="ApplicationService">
-      <name xml:lang="en">Dashboard Queries</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier2</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Data Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-c5c48e00-5410-4ce6-8ea5-a1656886c570" xsi:type="ApplicationInterface" specialization="JDBC">
-      <name xml:lang="en">Snowflake JDBC</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">JDBC</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">25000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">10000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0e10b2d0-b957-4f6e-90f2-fc2760e8971b" xsi:type="ApplicationService">
-      <name xml:lang="en">Legacy Data Migration</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationService-criticality_tier">
-          <value xml:lang="en">tier3</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationService-owning_team">
-          <value xml:lang="en">Data Engineering</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ce6916a3-7a07-483c-b9be-ea75955f5d08" xsi:type="ApplicationInterface" specialization="SFTP">
-      <name xml:lang="en">LEGACY.ETL.SFTP</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-protocol">
-          <value xml:lang="en">SFTP</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-avg_daily_volume">
-          <value xml:lang="en">1.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-ApplicationInterface-sla_ms">
-          <value xml:lang="en">7200000.0</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-968e3a57-7f21-40b3-96bd-55e75d548f22" xsi:type="Node" specialization="Kubernetes Cluster">
-      <name xml:lang="en">commerce-prod-eks</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">AWS</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">us-east-1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-82d66aca-2c0c-4416-9e85-764c058b5d2f" xsi:type="Node" specialization="Kubernetes Cluster">
-      <name xml:lang="en">services-prod-eks</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">AWS</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">us-east-1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-048f2567-af40-48a0-a08b-cf7b2462984e" xsi:type="Node" specialization="Kubernetes Cluster">
-      <name xml:lang="en">fulfillment-prod-eks</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">AWS</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">us-east-1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d858bd5f-7f76-4a33-b867-7ef356b181a5" xsi:type="Node" specialization="Kubernetes Cluster">
-      <name xml:lang="en">vet-prod-eks</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">AWS</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">us-east-1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-969d047e-e1ec-4525-acd0-1c8c1a75aac7" xsi:type="Node" specialization="VM">
-      <name xml:lang="en">pos-store-servers</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">on-prem</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">150 store locations</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0c9c75fe-694b-4b17-b33f-1abd1423f7ae" xsi:type="Node" specialization="VM">
-      <name xml:lang="en">erp-on-prem-cluster</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">on-prem</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">Ashburn DC</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-7e7548c1-a74b-4a05-904e-568b09d8f237" xsi:type="Node" specialization="VM">
-      <name xml:lang="en">legacy-mainframe</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">on-prem</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">Ashburn DC</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-54a86360-ff95-40ab-82ac-8ac09d9ba7e0" xsi:type="Node" specialization="Serverless">
-      <name xml:lang="en">workday-cloud</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-Node-cloud_provider">
-          <value xml:lang="en">Workday Cloud</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-region">
-          <value xml:lang="en">US</value>
-        </property>
-        <property propertyDefinitionRef="propdef-Node-environment">
-          <value xml:lang="en">production</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-42d31731-cbc4-4d21-8c36-5267bccd4c4a" xsi:type="SystemSoftware" specialization="Database">
-      <name xml:lang="en">Aurora PostgreSQL (Commerce)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">15.4</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en">2027-11-11</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">0.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f71fe3ef-f7ec-4c0e-82fb-43803219c430" xsi:type="SystemSoftware" specialization="Database">
-      <name xml:lang="en">Aurora PostgreSQL (Services)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">15.4</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en">2027-11-11</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">0.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f8f6be5b-190c-41cb-bddf-9fb08d70bb98" xsi:type="SystemSoftware" specialization="Database">
-      <name xml:lang="en">MongoDB Atlas</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">7.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">86000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-faa7d575-7c65-4b67-a6a8-756a20781ebe" xsi:type="SystemSoftware" specialization="Database">
-      <name xml:lang="en">Oracle 12c (Legacy)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">12.2.0.1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en">2022-03-31</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">420000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">retiring</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" xsi:type="SystemSoftware" specialization="Message Broker">
-      <name xml:lang="en">Amazon MSK (Kafka)</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">3.6</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">180000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b989268d-ad4d-4778-a073-5236fcb6937d" xsi:type="SystemSoftware" specialization="Message Broker">
-      <name xml:lang="en">IBM MQ</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">9.3</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en">2027-04-30</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">95000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">tolerated</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-88a66d97-5cc6-43b4-adbc-7aabc41c5928" xsi:type="SystemSoftware" specialization="Cache">
-      <name xml:lang="en">ElastiCache Redis</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">7.1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">48000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-9e1a0f63-ae68-4832-8baa-1aecc4e10920" xsi:type="SystemSoftware" specialization="Search Engine">
-      <name xml:lang="en">OpenSearch</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">2.11</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">62000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-4ee74f8c-7d73-48cb-a8e9-0690542c9399" xsi:type="SystemSoftware" specialization="CDN">
-      <name xml:lang="en">CloudFront CDN</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">96000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-a3aa253c-6c89-466f-a2bb-4ec7cd02fcaa" xsi:type="SystemSoftware" specialization="Database">
-      <name xml:lang="en">Snowflake</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">8.x</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">540000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0cf75019-c384-4d88-8198-a2305c524940" xsi:type="SystemSoftware" specialization="Runtime">
-      <name xml:lang="en">Tableau Server</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-SystemSoftware-version">
-          <value xml:lang="en">2024.1</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-end_of_support">
-          <value xml:lang="en"></value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-license_cost_annual">
-          <value xml:lang="en">185000.0</value>
-        </property>
-        <property propertyDefinitionRef="propdef-SystemSoftware-standardization_status">
-          <value xml:lang="en">standard</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="DataObject">
-      <name xml:lang="en">Customer</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Sarah Chen (VP Customer Experience)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">confidential</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.91</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">yes</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="DataObject">
-      <name xml:lang="en">Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Mike Torres (Dir. Commerce Engineering)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.94</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="DataObject">
-      <name xml:lang="en">Product</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Lisa Park (Dir. Merchandising)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.96</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="DataObject">
-      <name xml:lang="en">Inventory Position</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Raj Patel (Dir. Supply Chain)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.88</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-282c01e4-ff55-419e-bacd-c7929ecd4d9a" xsi:type="DataObject">
-      <name xml:lang="en">Payment Transaction</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">David Kim (Dir. Payments)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">restricted</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.99</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">yes</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-ddfb6085-3690-4e9c-afed-bb882ed1f7d9" xsi:type="DataObject">
-      <name xml:lang="en">Pet Profile</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Sarah Chen (VP Customer Experience)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">confidential</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.82</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">yes</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="DataObject">
-      <name xml:lang="en">Prescription</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Dr. Amy Roth (Vet Services Lead)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">restricted</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.95</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">yes</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="DataObject">
-      <name xml:lang="en">Subscription</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Jordan Blake (Dir. Subscription)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.9</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-9f8309fc-ae61-42c6-ae88-a6eaecdb257b" xsi:type="DataObject">
-      <name xml:lang="en">Vendor</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Raj Patel (Dir. Supply Chain)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.85</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-8596a9a0-4ca0-4872-890c-22dc7d5bee32" xsi:type="DataObject">
-      <name xml:lang="en">Financial Transaction</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">CFO Office</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">restricted</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.97</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">yes</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-047d6b74-9a9a-4d7b-a618-6047557fbc84" xsi:type="DataObject">
-      <name xml:lang="en">Employee</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">HR Leadership</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">confidential</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.93</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">yes</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-a161a0d7-4012-4520-aadc-1fb845687beb" xsi:type="DataObject">
-      <name xml:lang="en">Promotion</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Lisa Park (Dir. Merchandising)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.87</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-580bfdb8-2a15-494e-a28b-13190f3e52b7" xsi:type="DataObject">
-      <name xml:lang="en">Loyalty Account</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-DataObject-data_steward">
-          <value xml:lang="en">Sarah Chen (VP Customer Experience)</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-classification">
-          <value xml:lang="en">internal</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-quality_score">
-          <value xml:lang="en">0.92</value>
-        </property>
-        <property propertyDefinitionRef="propdef-DataObject-contains_pii">
-          <value xml:lang="en">no</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-2986d0cc-ce48-4ae7-b0d9-03ce2825972b" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Capture Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">passthrough</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b3671631-d48f-45c4-934e-c294463134be" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Validate &amp; Route Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">enrich</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-07d65b17-b7c5-4bc2-8c8e-9fe74f9d535a" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Allocate Inventory</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">filter</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-1c8f07da-52c1-4c7b-b330-45c761d5df20" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Authorize Payment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">enrich</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-805eaf8f-163c-4c08-998e-d4dada8e16a2" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Pick Pack Ship</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">transform</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-95b2a90d-1975-4a5d-9b0c-f53fa096592c" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Settle Payment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">aggregate</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-dc1efe1d-bcbe-469d-a6d3-29fecd8bbb6b" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Post to General Ledger</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">transform</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-002d4f5d-2094-49f9-9290-57284f792fb6" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Master Customer Profile</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">passthrough</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-dbc07ccc-dffc-433e-a31f-ca8a56caf5ef" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Display Customer Profile</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">filter</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-1d2cefb3-dc9e-46c0-a170-c35e61a27270" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Communication Preferences</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">filter</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d8f12227-97a4-4979-ab40-6a5bf881d468" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Customer Analytics Dataset</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">aggregate</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-d18dc771-1f39-4bc4-b754-9b6dc4d1bad9" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Record Stock Movement</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">passthrough</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-f49d0a94-fbff-4a4b-bf3b-58b600d333d3" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Update Inventory Position</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">aggregate</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-6faa5ed8-a5c7-4d41-9357-6210ae2dfaa6" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Forecast Demand</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">transform</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-189848ff-4de2-4a2c-96e9-f4f476e9cb85" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Generate Purchase Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">transform</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0de9eb59-0c4a-453e-9219-1b92640a5265" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Notify Supplier</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">filter</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-18d086df-5eff-433f-b32a-d67a9a0514a6" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Evaluate Autoship Eligibility</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">filter</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-e484cf55-2dc6-461e-aadd-53b5e93ccc21" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Charge Recurring Payment</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">enrich</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-7c52ed74-8259-4b77-a101-65e36ab09f4a" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Create Autoship Order</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">transform</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-b6b14185-4b38-490c-8c27-fe7ceb799b8b" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Fulfill Autoship</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">passthrough</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-727bfa7b-61c3-4216-911f-a9ee10d3462e" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Record Prescription</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">passthrough</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-0d3ab860-a023-4583-b805-bd4d8e3c5ea8" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Validate &amp; Queue Prescription</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">enrich</value>
-        </property>
-      </properties>
-    </element>
-    <element identifier="id-47aad289-34a5-494c-adb5-fd0abe0682f3" xsi:type="ApplicationProcess">
-      <name xml:lang="en">Notify Customer</name>
-      <properties>
-        <property propertyDefinitionRef="propdef-ApplicationProcess-transformation_type">
-          <value xml:lang="en">filter</value>
-        </property>
-      </properties>
-    </element>
-  </elements>
-  <relationships>
-    <relationship identifier="id-8ee23429-36f2-4e72-883e-d0be1c1f3b72" source="id-5147ffff-7e3c-4446-9171-edc14ff6b4f1" target="id-ed46fa05-a02c-480b-bca7-66e6c775fd95" xsi:type="Composition"/>
-    <relationship identifier="id-4150258a-f3f1-4054-bd2d-947d4e9b5dc5" source="id-5147ffff-7e3c-4446-9171-edc14ff6b4f1" target="id-b17a00bd-e844-421f-a562-385dcfc25951" xsi:type="Composition"/>
-    <relationship identifier="id-c7b3d699-bfce-4072-bae8-833e1ed80f39" source="id-5147ffff-7e3c-4446-9171-edc14ff6b4f1" target="id-38550322-65f8-4776-846c-f5f4dfb5c8f1" xsi:type="Composition"/>
-    <relationship identifier="id-53dab166-b3be-408e-b448-f7ba1f85bf4c" source="id-5147ffff-7e3c-4446-9171-edc14ff6b4f1" target="id-48524bca-869b-458c-8db9-4bd9de01cf93" xsi:type="Composition"/>
-    <relationship identifier="id-a0992760-cbe2-4e18-9f21-f7f144e139fd" source="id-57c73787-fba0-425a-a786-6cc51727a6fa" target="id-fe1e4ecf-9463-42d5-a791-8847265426fc" xsi:type="Composition"/>
-    <relationship identifier="id-9824e240-066d-4045-959f-a016a53428d2" source="id-57c73787-fba0-425a-a786-6cc51727a6fa" target="id-9762bbaf-d87a-427c-b1a3-b705dea78c23" xsi:type="Composition"/>
-    <relationship identifier="id-25186d2c-baa3-450a-8d67-ee3d51dc71a3" source="id-57c73787-fba0-425a-a786-6cc51727a6fa" target="id-7ced6d94-cffd-4f54-b7f0-8463450a1393" xsi:type="Composition"/>
-    <relationship identifier="id-6faa240d-6003-437d-a4d8-56ebfbc25456" source="id-57c73787-fba0-425a-a786-6cc51727a6fa" target="id-a003a667-c4fa-45ba-ad32-87243f9dbe9d" xsi:type="Composition"/>
-    <relationship identifier="id-135f7d35-e682-41af-a3c0-fab6a1a39a16" source="id-57c73787-fba0-425a-a786-6cc51727a6fa" target="id-5eaf4331-076d-49a0-9beb-64a0a30d4cef" xsi:type="Composition"/>
-    <relationship identifier="id-0dfca662-cd7d-401b-b7cb-1928b53ff424" source="id-a5bca47b-1c91-49c5-855d-6fc340e32e4b" target="id-235be7c0-8eb8-478f-8472-024658d663bd" xsi:type="Composition"/>
-    <relationship identifier="id-9ee7a7f2-42fb-4f78-afdc-5df3ec328d14" source="id-a5bca47b-1c91-49c5-855d-6fc340e32e4b" target="id-42986414-b483-4df0-9558-6836852d8bed" xsi:type="Composition"/>
-    <relationship identifier="id-7c18cb06-3dec-4e1a-a0fc-6eddd04d5827" source="id-a5bca47b-1c91-49c5-855d-6fc340e32e4b" target="id-0f5c40b0-fd27-4788-b0ef-cffc2f5a74fc" xsi:type="Composition"/>
-    <relationship identifier="id-de481abd-e237-4bfa-9426-12b166e14e4e" source="id-17c38a8d-43ae-4014-9ba1-1b640e90197e" target="id-62aeb9e5-adbc-49cd-b4ec-9a34d126ff02" xsi:type="Composition"/>
-    <relationship identifier="id-842a5c76-1a15-45d8-a788-25b086d0d31d" source="id-17c38a8d-43ae-4014-9ba1-1b640e90197e" target="id-8bdf2109-02af-4571-8d28-c74c90795171" xsi:type="Composition"/>
-    <relationship identifier="id-41f844be-9f9b-4602-875c-14d9b0abcd8b" source="id-17c38a8d-43ae-4014-9ba1-1b640e90197e" target="id-cd693def-f34e-48d2-a7e2-f15fa93ee5af" xsi:type="Composition"/>
-    <relationship identifier="id-8da87728-e2e8-47d6-b505-b4439e273a67" source="id-17c38a8d-43ae-4014-9ba1-1b640e90197e" target="id-e0d0162c-6978-45ce-93a8-d8dc40c261eb" xsi:type="Composition"/>
-    <relationship identifier="id-304f90e0-9ad5-4e27-99da-c8e12d31ef56" source="id-17c38a8d-43ae-4014-9ba1-1b640e90197e" target="id-85e1708b-21d0-48f4-aa8a-7a78736c70a4" xsi:type="Composition"/>
-    <relationship identifier="id-8bf172dd-2ec6-49d3-a27a-ca8cceba25d9" source="id-d20dc5c5-483a-4f4d-8721-0b40e7123c21" target="id-b5b893b0-baaa-43f9-bdd6-75da165124e3" xsi:type="Composition"/>
-    <relationship identifier="id-d33f5977-0042-4343-8f53-91e0b54b912c" source="id-d20dc5c5-483a-4f4d-8721-0b40e7123c21" target="id-83ec0e6e-49ce-4dc8-b46d-8e0f43131190" xsi:type="Composition"/>
-    <relationship identifier="id-8ef67071-683e-4398-a5b8-9e6722f005d4" source="id-d20dc5c5-483a-4f4d-8721-0b40e7123c21" target="id-f39adccd-f2aa-4d0f-8483-b1896eec326f" xsi:type="Composition"/>
-    <relationship identifier="id-75092aed-d885-47bf-be33-66063b5eeda4" source="id-86ec6dea-edf3-41a3-8154-2f85c008b8e3" target="id-456ac6f0-b4fa-46b2-9312-ff1ca17c7c1a" xsi:type="Composition"/>
-    <relationship identifier="id-6a73994d-31ba-4722-9e41-2a7a7e0835fe" source="id-86ec6dea-edf3-41a3-8154-2f85c008b8e3" target="id-b92544bb-08c9-4c14-9c47-1229295daa21" xsi:type="Composition"/>
-    <relationship identifier="id-c95fff84-81ca-4f06-9689-eb0f6e15beed" source="id-86ec6dea-edf3-41a3-8154-2f85c008b8e3" target="id-220b13a4-771a-4695-ac89-5a905b300013" xsi:type="Composition"/>
-    <relationship identifier="id-35c07622-f469-4e5e-9448-5c096031f7e5" source="id-9fc498b7-6079-4aaf-92cb-a62b621bcfd3" target="id-66d7da84-426e-4203-bad1-c6ee5e7b1dd1" xsi:type="Composition"/>
-    <relationship identifier="id-42b4a30b-58c3-4236-85c3-6e82a44dc93b" source="id-9fc498b7-6079-4aaf-92cb-a62b621bcfd3" target="id-c388a7d0-a5fe-4479-a28f-aafc511264c7" xsi:type="Composition"/>
-    <relationship identifier="id-c36667de-0ad2-4760-b287-3bc59fa78026" source="id-9fc498b7-6079-4aaf-92cb-a62b621bcfd3" target="id-cd79427f-7326-40ae-9684-955213811065" xsi:type="Composition"/>
-    <relationship identifier="id-d6401c6f-cd6a-4d6d-9b0d-aa8aa9a9a3ce" source="id-f68129f4-5d47-406a-9fb7-f6620379aef4" target="id-fe726c6b-2bbf-4fbd-846e-a8971dcb82dd" xsi:type="Composition"/>
-    <relationship identifier="id-b6270bc1-4687-4387-807b-fd93c89b1765" source="id-f68129f4-5d47-406a-9fb7-f6620379aef4" target="id-5b38a060-0f46-4256-8e29-f6ad5b4fc16a" xsi:type="Composition"/>
-    <relationship identifier="id-fbd00a6f-f790-407d-9dfe-1c6b63012100" source="id-f68129f4-5d47-406a-9fb7-f6620379aef4" target="id-71f39497-5e53-4731-b613-9eb5e7198622" xsi:type="Composition"/>
-    <relationship identifier="id-6b9ed59d-afec-4f2c-9de5-40504ecde355" source="id-08dcd9b6-17aa-433b-9ec9-2cc4d3a5a343" target="id-8107c641-e85c-4289-adae-33d968da3b4f" xsi:type="Composition"/>
-    <relationship identifier="id-03346458-e19f-4aa5-a298-1a145a81594a" source="id-08dcd9b6-17aa-433b-9ec9-2cc4d3a5a343" target="id-a115c0d9-e6e1-49db-acd2-d9c218950dc8" xsi:type="Composition"/>
-    <relationship identifier="id-ca320e8e-0a47-4c18-ba8d-931452711554" source="id-08dcd9b6-17aa-433b-9ec9-2cc4d3a5a343" target="id-9e3082e2-8452-4f9b-aa55-2ad3781bdc15" xsi:type="Composition"/>
-    <relationship identifier="id-40a7e815-29c5-418e-9dc4-135250b1b888" source="id-a26c4ac3-6f47-40a0-ae38-98f9a636e492" target="id-f3d69b91-b4b4-414d-a20a-3b4e2922413f" xsi:type="Composition"/>
-    <relationship identifier="id-df26ac66-1735-4128-a50c-13e1733b4db9" source="id-a26c4ac3-6f47-40a0-ae38-98f9a636e492" target="id-f1a0ca2d-c842-4b78-941f-1e825a12304b" xsi:type="Composition"/>
-    <relationship identifier="id-eee974ab-a4cd-4186-a00c-995892e3e5f9" source="id-a26c4ac3-6f47-40a0-ae38-98f9a636e492" target="id-6728ab07-3d40-47ee-b829-ae7c88073c47" xsi:type="Composition"/>
-    <relationship identifier="id-082b4bcc-400d-4447-80d7-75530e5649dd" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-fe1e4ecf-9463-42d5-a791-8847265426fc" xsi:type="Realization"/>
-    <relationship identifier="id-93a6a199-da01-409b-b915-a4c8f76ad74b" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-5eaf4331-076d-49a0-9beb-64a0a30d4cef" xsi:type="Realization"/>
-    <relationship identifier="id-82552215-0790-4b33-bfda-96ced3a7cc67" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-7ced6d94-cffd-4f54-b7f0-8463450a1393" xsi:type="Realization"/>
-    <relationship identifier="id-f9a45b60-bec1-4ee0-9fad-30b4af65de82" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-ed46fa05-a02c-480b-bca7-66e6c775fd95" xsi:type="Realization"/>
-    <relationship identifier="id-022742d7-a1b7-43ee-a029-65c31006cc20" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-9762bbaf-d87a-427c-b1a3-b705dea78c23" xsi:type="Realization"/>
-    <relationship identifier="id-3fad41ae-8c98-46fb-a164-01efd6cb8e85" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-38550322-65f8-4776-846c-f5f4dfb5c8f1" xsi:type="Realization"/>
-    <relationship identifier="id-8545a355-57f5-4b7e-993b-71d4f71cba0a" source="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" target="id-38550322-65f8-4776-846c-f5f4dfb5c8f1" xsi:type="Realization"/>
-    <relationship identifier="id-f195548d-18c5-4360-9a76-433999aa6cc8" source="id-9982a44e-9401-49c4-8476-47d813981582" target="id-a003a667-c4fa-45ba-ad32-87243f9dbe9d" xsi:type="Realization"/>
-    <relationship identifier="id-d53c05ca-ebdc-45e9-a944-644b8e894fbc" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-b17a00bd-e844-421f-a562-385dcfc25951" xsi:type="Realization"/>
-    <relationship identifier="id-f928d820-0908-4bd9-bc51-a62ea79138d3" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-ed46fa05-a02c-480b-bca7-66e6c775fd95" xsi:type="Realization"/>
-    <relationship identifier="id-dd701393-dcf9-42ba-854f-a8ea293f937c" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-48524bca-869b-458c-8db9-4bd9de01cf93" xsi:type="Realization"/>
-    <relationship identifier="id-8e15ae77-810e-4433-8c25-c7df4486de81" source="id-96325512-2329-4979-bffc-cd98fe460f5f" target="id-235be7c0-8eb8-478f-8472-024658d663bd" xsi:type="Realization"/>
-    <relationship identifier="id-40364a07-cab2-4af5-b222-5e0060b04cff" source="id-69217365-f468-43e6-a560-80a7b51fb83a" target="id-0f5c40b0-fd27-4788-b0ef-cffc2f5a74fc" xsi:type="Realization"/>
-    <relationship identifier="id-70d03487-ed5b-4d87-aec5-0d333135afa2" source="id-69217365-f468-43e6-a560-80a7b51fb83a" target="id-42986414-b483-4df0-9558-6836852d8bed" xsi:type="Realization"/>
-    <relationship identifier="id-85a5941e-57d6-4c2c-b5b9-b4ed6d597c08" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-62aeb9e5-adbc-49cd-b4ec-9a34d126ff02" xsi:type="Realization"/>
-    <relationship identifier="id-689b4aa5-01ef-4e4e-afb7-6cfe82aeffd3" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-e0d0162c-6978-45ce-93a8-d8dc40c261eb" xsi:type="Realization"/>
-    <relationship identifier="id-24d61abc-3707-418b-9f14-00de02d7675f" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-8bdf2109-02af-4571-8d28-c74c90795171" xsi:type="Realization"/>
-    <relationship identifier="id-d549e162-9db3-4312-8342-8644830c3313" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-cd693def-f34e-48d2-a7e2-f15fa93ee5af" xsi:type="Realization"/>
-    <relationship identifier="id-ce49319f-43a4-4817-8a67-4c760d0888a8" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-cd693def-f34e-48d2-a7e2-f15fa93ee5af" xsi:type="Realization"/>
-    <relationship identifier="id-d71acb79-db60-4598-bfab-8734e789d2e2" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-85e1708b-21d0-48f4-aa8a-7a78736c70a4" xsi:type="Realization"/>
-    <relationship identifier="id-b8992738-cbbf-4095-a06d-ddbc584c1e61" source="id-ab63e507-eb74-4d4f-aea3-fee26ca3c331" target="id-85e1708b-21d0-48f4-aa8a-7a78736c70a4" xsi:type="Realization"/>
-    <relationship identifier="id-5a1b9d0a-3f51-49a4-b451-8192d431dfea" source="id-73956421-5166-4390-8d3d-47cd1d27d7f9" target="id-b5b893b0-baaa-43f9-bdd6-75da165124e3" xsi:type="Realization"/>
-    <relationship identifier="id-ff437fb8-f2ff-47d2-aedc-3b8c19cb137d" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-83ec0e6e-49ce-4dc8-b46d-8e0f43131190" xsi:type="Realization"/>
-    <relationship identifier="id-1336aead-fbab-4c2c-8dcb-bfc5486fe869" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-f39adccd-f2aa-4d0f-8483-b1896eec326f" xsi:type="Realization"/>
-    <relationship identifier="id-7cd9a8f1-791b-4e2b-b997-ea7d0abbd4c5" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-456ac6f0-b4fa-46b2-9312-ff1ca17c7c1a" xsi:type="Realization"/>
-    <relationship identifier="id-74121cd7-9487-4a50-8ad4-713bc76ef856" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-b92544bb-08c9-4c14-9c47-1229295daa21" xsi:type="Realization"/>
-    <relationship identifier="id-b8f16c60-500f-4ff0-9573-9b5673275bb8" source="id-5489d56e-e12e-4a11-8211-49698a4cd712" target="id-220b13a4-771a-4695-ac89-5a905b300013" xsi:type="Realization"/>
-    <relationship identifier="id-8da0baf4-496f-417f-8297-afab88c92cbf" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-66d7da84-426e-4203-bad1-c6ee5e7b1dd1" xsi:type="Realization"/>
-    <relationship identifier="id-4a4030b3-4fe4-4830-98f5-d1fa1bb97cd0" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-c388a7d0-a5fe-4479-a28f-aafc511264c7" xsi:type="Realization"/>
-    <relationship identifier="id-2132e53e-8426-4999-b3e1-17614bc8082e" source="id-cfda2874-f06f-4483-be75-828739e80a01" target="id-cd79427f-7326-40ae-9684-955213811065" xsi:type="Realization"/>
-    <relationship identifier="id-b7d07502-698f-4d8b-ba23-03321670d310" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-fe726c6b-2bbf-4fbd-846e-a8971dcb82dd" xsi:type="Realization"/>
-    <relationship identifier="id-8bd323b6-3b00-4f92-881b-ef35197a0953" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-5b38a060-0f46-4256-8e29-f6ad5b4fc16a" xsi:type="Realization"/>
-    <relationship identifier="id-4e025e89-75f7-4a5f-a5ab-e4197a5f641c" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-71f39497-5e53-4731-b613-9eb5e7198622" xsi:type="Realization"/>
-    <relationship identifier="id-ed65edba-7be5-4cf0-b732-18a70c89faf1" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-8107c641-e85c-4289-adae-33d968da3b4f" xsi:type="Realization"/>
-    <relationship identifier="id-d64640e5-a814-4732-8725-1e240f6c8223" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-b92544bb-08c9-4c14-9c47-1229295daa21" xsi:type="Realization"/>
-    <relationship identifier="id-8081608a-4065-4e96-b94e-6dc1dae22ef5" source="id-ab39822b-d3cf-45fc-9c77-af528b94cab5" target="id-a115c0d9-e6e1-49db-acd2-d9c218950dc8" xsi:type="Realization"/>
-    <relationship identifier="id-c41cd07e-80f9-4bc0-8659-3c9b626b98d0" source="id-c5fa176f-ca05-4980-b55f-95def95ac15a" target="id-9e3082e2-8452-4f9b-aa55-2ad3781bdc15" xsi:type="Realization"/>
-    <relationship identifier="id-0f1a46ca-69c3-4c98-abba-11928e371cbb" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-f3d69b91-b4b4-414d-a20a-3b4e2922413f" xsi:type="Realization"/>
-    <relationship identifier="id-40655f5f-8920-4412-a3fa-58a62beb0e4c" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-f1a0ca2d-c842-4b78-941f-1e825a12304b" xsi:type="Realization"/>
-    <relationship identifier="id-35a3b58a-1461-4e2e-83a2-96bf8c74b077" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-6728ab07-3d40-47ee-b829-ae7c88073c47" xsi:type="Realization"/>
-    <relationship identifier="id-f243b33f-bbd4-4f10-8f32-376033975602" source="id-04ae0636-f529-45b4-9434-baa2a526c760" target="id-f3d69b91-b4b4-414d-a20a-3b4e2922413f" xsi:type="Realization"/>
-    <relationship identifier="id-5d55255d-b20d-475e-ac84-4af8faf6b585" source="id-cee73b55-c5e1-40d9-9f1d-de928bb317dc" target="id-f3d69b91-b4b4-414d-a20a-3b4e2922413f" xsi:type="Realization"/>
-    <relationship identifier="id-d6d116f9-15b1-4553-866d-6e963f641ebb" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-2259bc59-3fbc-4309-947d-1231c49c0888" xsi:type="Realization"/>
-    <relationship identifier="id-3cab1747-c4e3-486e-8ddf-34b9c4936c48" source="id-2259bc59-3fbc-4309-947d-1231c49c0888" target="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="Serving"/>
-    <relationship identifier="id-58be8924-a5c5-47da-82a4-6313bfce88bd" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-fde2a29c-43f2-4d6e-bd09-38c52265c985" xsi:type="Assignment"/>
-    <relationship identifier="id-0f2ec73f-d0be-4c09-ace6-f2360428f946" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-f6903c90-c9f9-4b73-b50a-b1e73bd38eed" xsi:type="Realization"/>
-    <relationship identifier="id-de6e4edf-ad35-4ca3-adff-3b73de149ec6" source="id-f6903c90-c9f9-4b73-b50a-b1e73bd38eed" target="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="Serving"/>
-    <relationship identifier="id-3a5c4680-5c07-43bf-8e86-03d26c7e56bf" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-e09d8178-1bf8-4e4a-884b-6078c48803f1" xsi:type="Assignment"/>
-    <relationship identifier="id-8cff76d5-f34b-45ef-bb76-235cd978bb62" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-24b4dbda-2153-4b68-8c03-0d3465d30c71" xsi:type="Realization"/>
-    <relationship identifier="id-dc0516fc-c1b6-40bf-80b9-cd4c2aa1cd44" source="id-24b4dbda-2153-4b68-8c03-0d3465d30c71" target="id-96325512-2329-4979-bffc-cd98fe460f5f" xsi:type="Serving"/>
-    <relationship identifier="id-64e63bc1-d6ec-4521-977c-5d90c03beea3" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-eb257e1f-d01f-44d8-ae5e-fea874936ef3" xsi:type="Assignment"/>
-    <relationship identifier="id-1b5bdaa6-22c8-44ac-ba43-6e3a20869795" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-b27ab851-e4f6-41d2-8f70-bc072a1aaae1" xsi:type="Realization"/>
-    <relationship identifier="id-29f8f1e6-e7ac-4cbb-868e-363a11169ec5" source="id-b27ab851-e4f6-41d2-8f70-bc072a1aaae1" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Serving"/>
-    <relationship identifier="id-500a80a4-28ed-4008-bda9-9c064238d5f5" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-18b703c8-6b1d-4e51-9e20-94f4bb707664" xsi:type="Assignment"/>
-    <relationship identifier="id-ee2cee90-8fd4-4a5c-a558-de9286104eb6" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-013151d1-a14a-48e7-9094-9a7fa5ec9993" xsi:type="Realization"/>
-    <relationship identifier="id-1483c985-211b-4698-8aae-c33da727751a" source="id-013151d1-a14a-48e7-9094-9a7fa5ec9993" target="id-73956421-5166-4390-8d3d-47cd1d27d7f9" xsi:type="Serving"/>
-    <relationship identifier="id-13670f4c-4b04-4109-b4b1-eb67b6b87d2b" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-dfb3df94-9c4c-4ce2-8bb2-fdb1453a1fd0" xsi:type="Assignment"/>
-    <relationship identifier="id-1fd19c2d-aba4-4c9a-90f3-0321277754b7" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-663dc6e1-c588-4ca9-aff1-c6c62a2a3373" xsi:type="Realization"/>
-    <relationship identifier="id-621f7e2c-4dbc-453c-8a7c-473adf349231" source="id-663dc6e1-c588-4ca9-aff1-c6c62a2a3373" target="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" xsi:type="Serving"/>
-    <relationship identifier="id-1e271e8e-b05a-482a-8ed8-a7f7b5e4288d" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-8ee38b61-7e47-43c3-adf9-959626de07d3" xsi:type="Assignment"/>
-    <relationship identifier="id-ea996288-f7ca-4630-ba37-1262bac1da26" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-21830b4c-49a6-42ad-993f-6ede4d98ae29" xsi:type="Realization"/>
-    <relationship identifier="id-593eb145-c4ba-4b29-938f-9ef6bbd8118f" source="id-21830b4c-49a6-42ad-993f-6ede4d98ae29" target="id-9982a44e-9401-49c4-8476-47d813981582" xsi:type="Serving"/>
-    <relationship identifier="id-b8964883-b78a-41ef-82bb-ff9a3d0b32c0" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-e42a3837-e677-456a-94c6-58016c7b328e" xsi:type="Assignment"/>
-    <relationship identifier="id-a28ea4cb-a75d-4c01-80db-60c3a9292f63" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-d46357fc-8e26-4004-b9d5-24cd2dc41bbd" xsi:type="Realization"/>
-    <relationship identifier="id-132fa675-95f7-4dab-bdb4-64fb1067c261" source="id-d46357fc-8e26-4004-b9d5-24cd2dc41bbd" target="id-73956421-5166-4390-8d3d-47cd1d27d7f9" xsi:type="Serving"/>
-    <relationship identifier="id-22098160-81a3-4930-825d-29a9f155edec" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-1f4e0852-ee46-44b0-9416-c51da0135aaa" xsi:type="Assignment"/>
-    <relationship identifier="id-01be1365-7811-4864-8256-727fb9cd7058" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-069b55e0-f5dc-425f-a807-1d59d982e885" xsi:type="Realization"/>
-    <relationship identifier="id-d7336598-d1e0-457e-9786-42bf55d09236" source="id-069b55e0-f5dc-425f-a807-1d59d982e885" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Serving"/>
-    <relationship identifier="id-9fa1f5b7-5a39-44c5-b632-11b0e7d54149" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-5f9194d3-45b3-40d7-8fb7-57ce416ea087" xsi:type="Assignment"/>
-    <relationship identifier="id-9eeb0b39-8f2e-4f42-a5e6-e0e8becc3711" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-66f4f6fa-1320-4736-b75d-c94e2ccbf94e" xsi:type="Realization"/>
-    <relationship identifier="id-d3d8e88f-552b-4111-8447-b054376bedc4" source="id-66f4f6fa-1320-4736-b75d-c94e2ccbf94e" target="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" xsi:type="Serving"/>
-    <relationship identifier="id-5f864d49-00d2-40ce-82f9-f6424065bfc8" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-bd23f2ce-59e2-4b49-8c65-3326fc3f23ea" xsi:type="Assignment"/>
-    <relationship identifier="id-09f326f0-b575-4bb2-ba0e-b1fdd2dbbfa1" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-c217519f-9434-444e-a64e-22098ae58871" xsi:type="Realization"/>
-    <relationship identifier="id-06348fdf-4179-4e5a-9ac4-2d01f45a8135" source="id-c217519f-9434-444e-a64e-22098ae58871" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Serving"/>
-    <relationship identifier="id-56062741-3a02-4397-a527-bdb71de0dce8" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-344ef3ce-df0a-4d55-b6b4-3add955d6df2" xsi:type="Assignment"/>
-    <relationship identifier="id-c2738122-bfa8-4d93-a36a-04ddeb8f4f70" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-acad5719-2942-4cd1-810b-ac5c0a91fd73" xsi:type="Realization"/>
-    <relationship identifier="id-dd6a57ba-dd57-48ea-b102-11bade18dcb3" source="id-acad5719-2942-4cd1-810b-ac5c0a91fd73" target="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" xsi:type="Serving"/>
-    <relationship identifier="id-dea11d49-988c-4fd3-903f-4edd57b05df7" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-884e033a-68e5-4e6a-b649-309078520a9c" xsi:type="Assignment"/>
-    <relationship identifier="id-344a4e16-09d9-4c81-9fc0-21ab17b93a95" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-e87291e3-4dbd-43ca-8e7d-af323f5ee8a4" xsi:type="Realization"/>
-    <relationship identifier="id-b4711b62-c827-4066-b391-8bad023a99dc" source="id-e87291e3-4dbd-43ca-8e7d-af323f5ee8a4" target="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" xsi:type="Serving"/>
-    <relationship identifier="id-73e302b8-a4fd-4041-853f-2a5914a57b37" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-b48d5eaf-cefd-4386-b952-417304392ac8" xsi:type="Assignment"/>
-    <relationship identifier="id-a5f8a4b3-c04b-4927-8e85-a6a75fc174b4" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-467dc55c-ff36-47d4-b4ed-96056fba3f21" xsi:type="Realization"/>
-    <relationship identifier="id-a5d50b05-cb01-453a-a37f-f69b9d25ffad" source="id-467dc55c-ff36-47d4-b4ed-96056fba3f21" target="id-ab63e507-eb74-4d4f-aea3-fee26ca3c331" xsi:type="Serving"/>
-    <relationship identifier="id-e37f6d55-b8d5-4286-a589-9cb6438d8e47" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-248d9a71-97b4-427b-9150-57cbbf04ac96" xsi:type="Assignment"/>
-    <relationship identifier="id-7e053edf-f5e0-4d25-9504-cdd3ab3c5233" source="id-73956421-5166-4390-8d3d-47cd1d27d7f9" target="id-4f55033f-9231-40fd-a661-89bacbfd7167" xsi:type="Realization"/>
-    <relationship identifier="id-6d3d757c-33d4-4fc0-9122-ac1b606b8cf1" source="id-4f55033f-9231-40fd-a661-89bacbfd7167" target="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" xsi:type="Serving"/>
-    <relationship identifier="id-fcba25ec-4a2e-4460-9b47-2497e1564394" source="id-73956421-5166-4390-8d3d-47cd1d27d7f9" target="id-42ad9d64-6de8-48bd-9364-e03af8a3c70a" xsi:type="Assignment"/>
-    <relationship identifier="id-ed31878a-b814-40e0-bf39-8b74d422cad0" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-1d8d35aa-0b70-4a81-b79c-ae917c0acba4" xsi:type="Realization"/>
-    <relationship identifier="id-58743ee9-ec4d-4527-8578-84b3baeda9f0" source="id-1d8d35aa-0b70-4a81-b79c-ae917c0acba4" target="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" xsi:type="Serving"/>
-    <relationship identifier="id-f3c52a85-73bf-4724-b9a6-2d2f7cd105a2" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-4fcae0d6-f003-48d1-8ba4-057059f6f6ff" xsi:type="Assignment"/>
-    <relationship identifier="id-e2ee9247-899d-4279-94f4-439b77373044" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-b8bdfe19-33ba-4fff-8702-12472e2d8081" xsi:type="Realization"/>
-    <relationship identifier="id-22c8b685-eb99-4725-9679-638d92efb662" source="id-b8bdfe19-33ba-4fff-8702-12472e2d8081" target="id-6da69574-e14e-4505-a320-3b086578f026" xsi:type="Serving"/>
-    <relationship identifier="id-74943fc9-05ca-48fd-9428-21479d657a80" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-2047f33c-0e88-423a-8e5e-a47bc36efd14" xsi:type="Assignment"/>
-    <relationship identifier="id-fc5acf06-295a-44cf-ba1b-eacef2ca9f69" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-fbdf79a5-dc93-4976-8bab-4fc039a27565" xsi:type="Realization"/>
-    <relationship identifier="id-826dfe06-0569-422b-9bd0-61f7ff466ebb" source="id-fbdf79a5-dc93-4976-8bab-4fc039a27565" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Serving"/>
-    <relationship identifier="id-57e19fdb-8929-4e17-a004-0f9bbaa10ca9" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-5ecf051b-cb5c-482e-8ce9-a14f165bbfcb" xsi:type="Assignment"/>
-    <relationship identifier="id-9d027f62-ca39-4d1a-aab8-829a1baf6059" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-4ea62834-30b4-46e1-ae1f-f707a70e158e" xsi:type="Realization"/>
-    <relationship identifier="id-f33815ed-23ac-4468-92f4-552192f59c15" source="id-4ea62834-30b4-46e1-ae1f-f707a70e158e" target="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" xsi:type="Serving"/>
-    <relationship identifier="id-93aa0e7b-12d7-4a96-9e91-e5748c763640" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-67698cac-a6bc-492f-bc51-fbd94958298d" xsi:type="Assignment"/>
-    <relationship identifier="id-599a442c-1de8-454b-a81b-f6dd7e8b8b91" source="id-69217365-f468-43e6-a560-80a7b51fb83a" target="id-5f7fe9d8-03e2-4c94-8a85-09bc4c3619ad" xsi:type="Realization"/>
-    <relationship identifier="id-f0585052-1700-43e5-acdc-2cc934c1dc7d" source="id-5f7fe9d8-03e2-4c94-8a85-09bc4c3619ad" target="id-5489d56e-e12e-4a11-8211-49698a4cd712" xsi:type="Serving"/>
-    <relationship identifier="id-3626aaaa-4a58-4ab8-b174-8779c2dad3d7" source="id-69217365-f468-43e6-a560-80a7b51fb83a" target="id-4e37222c-009f-4d25-983e-407ce032bf76" xsi:type="Assignment"/>
-    <relationship identifier="id-33b19be0-e54f-46dc-8a77-bfba53709833" source="id-5489d56e-e12e-4a11-8211-49698a4cd712" target="id-230a77e5-0042-445d-9e3b-ef1966c13c0f" xsi:type="Realization"/>
-    <relationship identifier="id-c2d115a7-7dc4-40a8-94ac-aa42c2356ea8" source="id-230a77e5-0042-445d-9e3b-ef1966c13c0f" target="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" xsi:type="Serving"/>
-    <relationship identifier="id-8884a0a5-4cac-4028-abf8-6bd26455e74e" source="id-5489d56e-e12e-4a11-8211-49698a4cd712" target="id-c4ad7f06-9b82-49bc-a1af-c6e05fbc6c92" xsi:type="Assignment"/>
-    <relationship identifier="id-4cc7121e-5b90-4d3b-b7df-2f80b81594f7" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-97317099-f839-4d4c-9439-4f50129fcb12" xsi:type="Realization"/>
-    <relationship identifier="id-c439e12f-71af-41d9-97f1-a2fdfd5ebf4a" source="id-97317099-f839-4d4c-9439-4f50129fcb12" target="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="Serving"/>
-    <relationship identifier="id-abcf8120-cec4-4337-8ce6-1d5be8515623" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-9241c699-edb4-4562-a222-0a4b96982645" xsi:type="Assignment"/>
-    <relationship identifier="id-49acc07d-1892-4ebf-803b-ae0796ecad98" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-698607a7-b0d9-4ad0-9e00-7e46286ff3fe" xsi:type="Realization"/>
-    <relationship identifier="id-be38290f-77ab-4cf0-af59-c9aadfe35f7e" source="id-698607a7-b0d9-4ad0-9e00-7e46286ff3fe" target="id-cfda2874-f06f-4483-be75-828739e80a01" xsi:type="Serving"/>
-    <relationship identifier="id-df98aa42-2ab6-4acb-9d3d-2b7e180157c5" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-9043a34f-20e1-458d-a1bd-1ae3191735d6" xsi:type="Assignment"/>
-    <relationship identifier="id-42b13f42-f1b0-4ab5-8686-ac1085c25192" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-ef59bddb-7cfb-4665-bafd-3ae1227fefe3" xsi:type="Realization"/>
-    <relationship identifier="id-2b9632ea-b724-4472-8d83-b8df1efc75c8" source="id-ef59bddb-7cfb-4665-bafd-3ae1227fefe3" target="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="Serving"/>
-    <relationship identifier="id-28421732-9f10-41e5-88d6-95c94ecf89ca" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-d71241b0-9369-4aaf-a201-e210d422bd26" xsi:type="Assignment"/>
-    <relationship identifier="id-9cf2c3c4-a884-4f03-ac74-793db0de7ca3" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-1c89eac6-a089-495f-b495-e19852777a08" xsi:type="Realization"/>
-    <relationship identifier="id-b4ba52af-235a-45d9-a209-21b46c754fb9" source="id-1c89eac6-a089-495f-b495-e19852777a08" target="id-73956421-5166-4390-8d3d-47cd1d27d7f9" xsi:type="Serving"/>
-    <relationship identifier="id-f5e0d4bf-77b3-4464-a149-79a4f642dc58" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-f5d5fe1c-0a4a-4c43-a855-77161dbbbb86" xsi:type="Assignment"/>
-    <relationship identifier="id-65becbc3-9932-4570-ac20-2d37f877ba16" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-af166859-ee32-4496-9266-17eaf967d444" xsi:type="Realization"/>
-    <relationship identifier="id-838c0d94-cbfb-47f3-990b-91ffec3e9fab" source="id-af166859-ee32-4496-9266-17eaf967d444" target="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" xsi:type="Serving"/>
-    <relationship identifier="id-5f7f9130-05d6-43eb-b309-2c7fc3a90f41" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-fd1a9e91-1e5b-4a67-a37d-5f7ab1c4ff45" xsi:type="Assignment"/>
-    <relationship identifier="id-24b820e7-f9bd-4e20-b39b-e8e906bbac90" source="id-cfda2874-f06f-4483-be75-828739e80a01" target="id-0794a1bb-59be-4070-a5ad-b1e7b9d0ee35" xsi:type="Realization"/>
-    <relationship identifier="id-81eca108-a748-4559-a195-24b0cf3c01e2" source="id-0794a1bb-59be-4070-a5ad-b1e7b9d0ee35" target="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" xsi:type="Serving"/>
-    <relationship identifier="id-a3e5c920-c148-42cc-b43c-8b754f5a054d" source="id-cfda2874-f06f-4483-be75-828739e80a01" target="id-ff8e545c-10bb-4dd9-a993-0827c1b78ac1" xsi:type="Assignment"/>
-    <relationship identifier="id-edb332a6-d1af-496c-9dc0-d0c6cb9dd259" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-83434bde-ea53-4942-93f7-626809444268" xsi:type="Realization"/>
-    <relationship identifier="id-f92e5bc3-a9c6-45f1-aac7-8ace5ebd1a8d" source="id-83434bde-ea53-4942-93f7-626809444268" target="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="Serving"/>
-    <relationship identifier="id-14cc5c9b-0a44-4883-827f-0f5fd4cc558b" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-d0ebb5bc-56aa-4360-a170-149c020d7067" xsi:type="Assignment"/>
-    <relationship identifier="id-86cea32d-c831-4554-9595-47b34cb9b7d3" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-d3cdd3bb-eaa9-42d1-a51f-55818da5a92f" xsi:type="Realization"/>
-    <relationship identifier="id-c5ccf9c5-8181-4a1d-a4b4-341da710565b" source="id-d3cdd3bb-eaa9-42d1-a51f-55818da5a92f" target="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="Serving"/>
-    <relationship identifier="id-9a5fc6db-d79a-42a0-8357-264bfe2defd4" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-7313af28-0841-4c04-a9e5-d3a977b2dc77" xsi:type="Assignment"/>
-    <relationship identifier="id-c56df7cd-b90a-424d-8b8d-1d0cf54336b3" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-d86709f2-7ac9-4971-a1d2-73d35dabd602" xsi:type="Realization"/>
-    <relationship identifier="id-b35cea1a-46a8-4b2e-8ac9-0ca6d046e7eb" source="id-d86709f2-7ac9-4971-a1d2-73d35dabd602" target="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="Serving"/>
-    <relationship identifier="id-d3291f28-374d-4069-9f24-49ad881bb272" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-db13b01b-1483-4c64-87ca-5f055ea9e514" xsi:type="Assignment"/>
-    <relationship identifier="id-50fa5925-8d24-450b-a641-95242ac286d5" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-f2906ff2-7622-4f93-ad84-201dc18df7cc" xsi:type="Realization"/>
-    <relationship identifier="id-78f6949d-a9e3-48f1-a2ab-8fa9be02e583" source="id-f2906ff2-7622-4f93-ad84-201dc18df7cc" target="id-04ae0636-f529-45b4-9434-baa2a526c760" xsi:type="Serving"/>
-    <relationship identifier="id-55e72686-c162-44d9-af20-7d21e796e139" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-c5c48e00-5410-4ce6-8ea5-a1656886c570" xsi:type="Assignment"/>
-    <relationship identifier="id-94d5e0ba-5380-4258-abb5-8dbf62c9b6b2" source="id-cee73b55-c5e1-40d9-9f1d-de928bb317dc" target="id-0e10b2d0-b957-4f6e-90f2-fc2760e8971b" xsi:type="Realization"/>
-    <relationship identifier="id-042909f1-0a46-4910-b291-8842d7ba164a" source="id-0e10b2d0-b957-4f6e-90f2-fc2760e8971b" target="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="Serving"/>
-    <relationship identifier="id-40cc9164-d43d-467e-940f-eb33372904b8" source="id-cee73b55-c5e1-40d9-9f1d-de928bb317dc" target="id-ce6916a3-7a07-483c-b9be-ea75955f5d08" xsi:type="Assignment"/>
-    <relationship identifier="id-66aa24d9-9446-4fed-a8b8-a918dda31dea" source="id-968e3a57-7f21-40b3-96bd-55e75d548f22" target="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" xsi:type="Realization"/>
-    <relationship identifier="id-a3c1eaea-bff2-44bb-99b9-50a538718ddb" source="id-968e3a57-7f21-40b3-96bd-55e75d548f22" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Realization"/>
-    <relationship identifier="id-8cfc7819-d5a7-4fd4-9cd3-6df9c92fc81f" source="id-968e3a57-7f21-40b3-96bd-55e75d548f22" target="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="Realization"/>
-    <relationship identifier="id-8df75d64-afb9-4469-b05d-c64733436212" source="id-968e3a57-7f21-40b3-96bd-55e75d548f22" target="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" xsi:type="Realization"/>
-    <relationship identifier="id-4cc500c0-4f5a-4ec4-9d4d-1451e6e391ae" source="id-968e3a57-7f21-40b3-96bd-55e75d548f22" target="id-9982a44e-9401-49c4-8476-47d813981582" xsi:type="Realization"/>
-    <relationship identifier="id-26eacc34-353d-4421-b233-978d7da4f5b6" source="id-82d66aca-2c0c-4416-9e85-764c058b5d2f" target="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="Realization"/>
-    <relationship identifier="id-f0d10d74-7605-4537-a93d-0b55b3c9d601" source="id-82d66aca-2c0c-4416-9e85-764c058b5d2f" target="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" xsi:type="Realization"/>
-    <relationship identifier="id-c8732a44-cc03-4cbc-8d19-e3f495c03a79" source="id-82d66aca-2c0c-4416-9e85-764c058b5d2f" target="id-96325512-2329-4979-bffc-cd98fe460f5f" xsi:type="Realization"/>
-    <relationship identifier="id-a9d71882-c37c-468d-9da0-52b034e13aff" source="id-82d66aca-2c0c-4416-9e85-764c058b5d2f" target="id-73956421-5166-4390-8d3d-47cd1d27d7f9" xsi:type="Realization"/>
-    <relationship identifier="id-90b8ba88-33d6-479d-8589-caf09591b5a0" source="id-048f2567-af40-48a0-a08b-cf7b2462984e" target="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" xsi:type="Realization"/>
-    <relationship identifier="id-d11055c7-ae3c-4109-8610-d66d7c7f5f13" source="id-048f2567-af40-48a0-a08b-cf7b2462984e" target="id-6da69574-e14e-4505-a320-3b086578f026" xsi:type="Realization"/>
-    <relationship identifier="id-562cdad9-8d07-4fd3-aa37-5d7a5bc3fefa" source="id-048f2567-af40-48a0-a08b-cf7b2462984e" target="id-5489d56e-e12e-4a11-8211-49698a4cd712" xsi:type="Realization"/>
-    <relationship identifier="id-20f23264-5cd1-4828-a3df-2e0237cb32ff" source="id-d858bd5f-7f76-4a33-b867-7ef356b181a5" target="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" xsi:type="Realization"/>
-    <relationship identifier="id-2132e688-59e2-4f06-9ddb-3053acf77f13" source="id-d858bd5f-7f76-4a33-b867-7ef356b181a5" target="id-cfda2874-f06f-4483-be75-828739e80a01" xsi:type="Realization"/>
-    <relationship identifier="id-86b21c8f-451f-4e31-a536-f616cd601b0e" source="id-d858bd5f-7f76-4a33-b867-7ef356b181a5" target="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" xsi:type="Realization"/>
-    <relationship identifier="id-a57d6f34-9f9d-4a4e-831c-295b4a921079" source="id-969d047e-e1ec-4525-acd0-1c8c1a75aac7" target="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" xsi:type="Realization"/>
-    <relationship identifier="id-136437b6-3b23-4b4e-a475-3259d8e15001" source="id-0c9c75fe-694b-4b17-b33f-1abd1423f7ae" target="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" xsi:type="Realization"/>
-    <relationship identifier="id-af9e5bd7-a9f4-4de3-a9c6-734579238ca3" source="id-7e7548c1-a74b-4a05-904e-568b09d8f237" target="id-ab63e507-eb74-4d4f-aea3-fee26ca3c331" xsi:type="Realization"/>
-    <relationship identifier="id-74d70da3-4b12-40f8-b613-bba224dfa9da" source="id-54a86360-ff95-40ab-82ac-8ac09d9ba7e0" target="id-ab39822b-d3cf-45fc-9c77-af528b94cab5" xsi:type="Realization"/>
-    <relationship identifier="id-9121c3fe-07f6-47ab-ade3-835df18c90b6" source="id-42d31731-cbc4-4d21-8c36-5267bccd4c4a" target="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" xsi:type="Realization"/>
-    <relationship identifier="id-9f503ad5-5829-4ca2-ad7d-cc2106d62bd4" source="id-42d31731-cbc4-4d21-8c36-5267bccd4c4a" target="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="Realization"/>
-    <relationship identifier="id-9f7a79a7-cbe7-46f7-b3ea-c50a9ab628b1" source="id-42d31731-cbc4-4d21-8c36-5267bccd4c4a" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Realization"/>
-    <relationship identifier="id-b0015d9b-b268-4a3c-a643-fb7d2fbd87f3" source="id-f71fe3ef-f7ec-4c0e-82fb-43803219c430" target="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="Realization"/>
-    <relationship identifier="id-42f12047-2ed1-4cc9-9e4c-3d9dbfceff79" source="id-f71fe3ef-f7ec-4c0e-82fb-43803219c430" target="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" xsi:type="Realization"/>
-    <relationship identifier="id-7efb80da-2711-4e40-9c73-2ab965dc3bcb" source="id-f71fe3ef-f7ec-4c0e-82fb-43803219c430" target="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" xsi:type="Realization"/>
-    <relationship identifier="id-888e2458-d405-42cd-81a0-7ee6400dc307" source="id-f8f6be5b-190c-41cb-bddf-9fb08d70bb98" target="id-96325512-2329-4979-bffc-cd98fe460f5f" xsi:type="Realization"/>
-    <relationship identifier="id-26acd3a3-ea61-4d6a-b160-23a3542e023f" source="id-f8f6be5b-190c-41cb-bddf-9fb08d70bb98" target="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" xsi:type="Realization"/>
-    <relationship identifier="id-a2517b2a-c225-4a11-8d2f-bb21f38cb1e3" source="id-faa7d575-7c65-4b67-a6a8-756a20781ebe" target="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" xsi:type="Realization"/>
-    <relationship identifier="id-3d969a73-d182-4eb7-b9a7-516f916993f8" source="id-faa7d575-7c65-4b67-a6a8-756a20781ebe" target="id-cee73b55-c5e1-40d9-9f1d-de928bb317dc" xsi:type="Realization"/>
-    <relationship identifier="id-ddd57bc3-0666-4a8d-8a76-37f81cd07a58" source="id-faa7d575-7c65-4b67-a6a8-756a20781ebe" target="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" xsi:type="Realization"/>
-    <relationship identifier="id-fc2ae006-7355-4cf9-b851-8dfb597d9359" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="Realization"/>
-    <relationship identifier="id-55c6215b-9d4f-4124-bc82-c2132703d191" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Realization"/>
-    <relationship identifier="id-ca631e6a-eec7-4c3d-9da0-c5164c3882c9" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-73956421-5166-4390-8d3d-47cd1d27d7f9" xsi:type="Realization"/>
-    <relationship identifier="id-b4a10b0f-5432-4697-9038-656ff88b9db6" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="Realization"/>
-    <relationship identifier="id-601d57b4-755c-4c0f-ba0b-774ea62b9022" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" xsi:type="Realization"/>
-    <relationship identifier="id-1273bd32-7f7d-4b39-bab4-f05a067a6587" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" xsi:type="Realization"/>
-    <relationship identifier="id-af1ddd4f-530c-4ef6-89c6-580dc673a8a0" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" xsi:type="Realization"/>
-    <relationship identifier="id-c46ac6a4-a407-4265-8cb3-e5efd5dfbe97" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-cfda2874-f06f-4483-be75-828739e80a01" xsi:type="Realization"/>
-    <relationship identifier="id-0917a1ae-6126-4b04-a840-09743f0019ad" source="id-65702bc7-e251-465a-a3fb-fd7a0fcaa672" target="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="Realization"/>
-    <relationship identifier="id-34e930be-0523-4e12-85e8-8bf62e2f7c85" source="id-b989268d-ad4d-4778-a073-5236fcb6937d" target="id-ab63e507-eb74-4d4f-aea3-fee26ca3c331" xsi:type="Realization"/>
-    <relationship identifier="id-96109dfe-8b80-4b2b-8269-ec9649c724c1" source="id-b989268d-ad4d-4778-a073-5236fcb6937d" target="id-8b321e08-7e5e-4243-b386-e2fec7343dae" xsi:type="Realization"/>
-    <relationship identifier="id-9bda4ba6-b059-42ef-897d-dda74a618c1a" source="id-88a66d97-5cc6-43b4-adbc-7aabc41c5928" target="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" xsi:type="Realization"/>
-    <relationship identifier="id-e6251ae0-d000-4d3e-bd60-d45fbe3142b4" source="id-88a66d97-5cc6-43b4-adbc-7aabc41c5928" target="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" xsi:type="Realization"/>
-    <relationship identifier="id-519296df-c4e2-4d8e-ad06-7435f4a295c7" source="id-88a66d97-5cc6-43b4-adbc-7aabc41c5928" target="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" xsi:type="Realization"/>
-    <relationship identifier="id-e8583c3c-a598-4373-8edc-97e39659aeb5" source="id-9e1a0f63-ae68-4832-8baa-1aecc4e10920" target="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" xsi:type="Realization"/>
-    <relationship identifier="id-876f733b-6e7e-43cc-af4e-54cb7473a522" source="id-9e1a0f63-ae68-4832-8baa-1aecc4e10920" target="id-96325512-2329-4979-bffc-cd98fe460f5f" xsi:type="Realization"/>
-    <relationship identifier="id-49310600-5c7b-4d43-8a68-7aaaf80e6687" source="id-4ee74f8c-7d73-48cb-a8e9-0690542c9399" target="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" xsi:type="Realization"/>
-    <relationship identifier="id-aa088946-323a-41a8-ae8a-3de8e6e376ff" source="id-4ee74f8c-7d73-48cb-a8e9-0690542c9399" target="id-04ae0636-f529-45b4-9434-baa2a526c760" xsi:type="Realization"/>
-    <relationship identifier="id-8a28d87e-549a-423e-bc8f-243dfc1fe3d9" source="id-a3aa253c-6c89-466f-a2bb-4ec7cd02fcaa" target="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" xsi:type="Realization"/>
-    <relationship identifier="id-83c454d6-5c18-433b-8103-1e3fd833f9f2" source="id-0cf75019-c384-4d88-8198-a2305c524940" target="id-04ae0636-f529-45b4-9434-baa2a526c760" xsi:type="Realization"/>
-    <relationship identifier="id-a4e890cf-8a0d-46f1-aa0d-e538fd7d0438" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-d603d57a-555a-40c4-9991-5d2248993ea5" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-aa0fa5fe-0c0a-47c4-aa5f-a03efc634922" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-92dc25c9-dd0f-479b-b8d8-bffde60caf24" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-5d15a87a-f1ce-45fb-bc47-01b5eeaca874" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-24d56f2b-0ad1-456f-8553-00410c16902d" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-5d5560d1-31e4-4d3e-959f-e052ccce671e" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-4a65e364-51e0-4dfc-817b-40f31002be67" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-d328a37c-e9b0-4344-975e-9c7381ebeaf9" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-1cf62a17-e4d4-4e0d-8ae3-4a6478a0440d" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-389be811-90f3-45f1-ad18-7d993e960237" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-2e33dae2-1490-4188-ad54-373dd972d4d6" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-0eab5bfb-0199-42d9-9434-5c7ee0faed4f" source="id-96325512-2329-4979-bffc-cd98fe460f5f" target="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-659ea750-953a-4e71-a238-094f1ca51737" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-6e73f207-6f1a-42fe-bc9f-b1d2d075f9e6" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-ed29c4bf-afcd-437e-9728-56164353db6e" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-d9b801f1-1471-41d9-9749-860d30e5d4ca" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-0c7ae5ea-d055-4180-ab01-1a4e0af3ae8c" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-34a96447-a303-4cf0-9c1d-44377f8cef1a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-af084b76-47c0-4503-b7d6-2c9739f27da4" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-fd183c71-5f7b-4419-9860-912d9943bd7d" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-4479684d-1bab-405a-879a-57706f3c338a" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-bacde231-9283-4f8c-9dcc-15fa7918042d" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-7571c598-7dd2-4f6c-ba3d-5a111e376869" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-f51317ce-6c34-4ef7-b0bb-07d7f52081cc" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-cc99ced1-dee0-439b-8640-f6d4e9e2b61c" source="id-73956421-5166-4390-8d3d-47cd1d27d7f9" target="id-282c01e4-ff55-419e-bacd-c7929ecd4d9a" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-b84d138b-f779-4ee6-b5c5-cccd3c2f5b39" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-282c01e4-ff55-419e-bacd-c7929ecd4d9a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-5bf4bdc0-2c51-41de-a509-e8d423ae872b" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-282c01e4-ff55-419e-bacd-c7929ecd4d9a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-543e5c7b-de30-47c4-85a2-6143fda1e338" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-282c01e4-ff55-419e-bacd-c7929ecd4d9a" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-e8481784-5b0b-4c9c-b3f3-fd570841a860" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-ddfb6085-3690-4e9c-afed-bb882ed1f7d9" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-14bfea9d-04c3-46d7-962c-32dcf76e979e" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-ddfb6085-3690-4e9c-afed-bb882ed1f7d9" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-36f507b7-ab5b-4285-91f7-595decdc13bd" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-ddfb6085-3690-4e9c-afed-bb882ed1f7d9" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-7e219e2b-ceeb-4cc1-b119-ddf08c0b05fa" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-ddfb6085-3690-4e9c-afed-bb882ed1f7d9" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-5e07fddc-e49d-4007-959c-cfbe27fd7d98" source="id-cfda2874-f06f-4483-be75-828739e80a01" target="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-84099b6e-6686-409a-9d01-67a80e9611ec" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-515ea1df-5b45-4fef-a45b-04cfd9047e14" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-065b8546-90d3-4f13-b130-7350a98fc36a" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-df1cc685-2c72-4ea0-a318-bce963dedf13" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-1e2d5525-42cd-438c-bd42-4555114bd805" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-f80542ec-8d9c-4a98-8746-d3333a4c0245" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-6f9f43b0-14d9-4c83-977c-765fefe14e01" source="id-69217365-f468-43e6-a560-80a7b51fb83a" target="id-9f8309fc-ae61-42c6-ae88-a6eaecdb257b" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-18c7d03b-1088-4d4c-9e1f-ec45ed01b419" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-9f8309fc-ae61-42c6-ae88-a6eaecdb257b" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-bfa05abd-e24d-42bf-bb0a-c3898a640916" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-9f8309fc-ae61-42c6-ae88-a6eaecdb257b" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-16845eda-6252-4229-b12c-678953323594" source="id-5489d56e-e12e-4a11-8211-49698a4cd712" target="id-9f8309fc-ae61-42c6-ae88-a6eaecdb257b" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-0a590553-62ce-44c6-abb4-561f5aadb987" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-8596a9a0-4ca0-4872-890c-22dc7d5bee32" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-169ee149-045f-440f-916b-e25980a439cf" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-8596a9a0-4ca0-4872-890c-22dc7d5bee32" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-69cecdae-7dea-4069-ae9a-fb55c3599e0a" source="id-cee73b55-c5e1-40d9-9f1d-de928bb317dc" target="id-8596a9a0-4ca0-4872-890c-22dc7d5bee32" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-18e40858-427e-4625-8238-7db135e079ab" source="id-ab39822b-d3cf-45fc-9c77-af528b94cab5" target="id-047d6b74-9a9a-4d7b-a618-6047557fbc84" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-bb3b80e1-721f-4f7e-befe-b62b93609cca" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-047d6b74-9a9a-4d7b-a618-6047557fbc84" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-31b1b57a-d913-49cb-ba8a-b51e467e9971" source="id-c5fa176f-ca05-4980-b55f-95def95ac15a" target="id-047d6b74-9a9a-4d7b-a618-6047557fbc84" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-65fd5f45-c42f-42b9-b6ac-b6a33dd0d00c" source="id-9982a44e-9401-49c4-8476-47d813981582" target="id-a161a0d7-4012-4520-aadc-1fb845687beb" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-23f4573e-cead-45b5-a8f3-250294452b8b" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-a161a0d7-4012-4520-aadc-1fb845687beb" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-3f9a0659-c9fc-411c-8fa6-b99635c9e26d" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-a161a0d7-4012-4520-aadc-1fb845687beb" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-f9c69fb5-cf14-43dd-a193-91905eacd47e" source="id-a1094e41-82d1-4b97-a536-e98140f7e1f9" target="id-580bfdb8-2a15-494e-a28b-13190f3e52b7" xsi:type="Access" accessType="Write">
-      <name xml:lang="en">system of record</name>
-    </relationship>
-    <relationship identifier="id-edba103a-3a1f-46d4-ac85-ec4fe661e3d7" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-580bfdb8-2a15-494e-a28b-13190f3e52b7" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-67e304a5-c571-4d2e-ac3a-ee90cef2c937" source="id-268fdf34-39b5-4ddf-b0de-46787f72a02d" target="id-580bfdb8-2a15-494e-a28b-13190f3e52b7" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-9815002e-9404-421b-9fb4-78f4ce7f9056" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-580bfdb8-2a15-494e-a28b-13190f3e52b7" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-117cdb32-fd9d-48f0-bb5b-32c1a397930d" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-580bfdb8-2a15-494e-a28b-13190f3e52b7" xsi:type="Access" accessType="Read">
-      <name xml:lang="en">system of reference</name>
-    </relationship>
-    <relationship identifier="id-ac7f2c06-273c-467d-a476-f2f9a80e1881" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-2986d0cc-ce48-4ae7-b0d9-03ce2825972b" xsi:type="Realization"/>
-    <relationship identifier="id-db131837-a50f-45b5-a7b4-09c224f04465" source="id-2986d0cc-ce48-4ae7-b0d9-03ce2825972b" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-e31dcde7-9c79-45b7-8c4e-992d6ad06d7d" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-b3671631-d48f-45c4-934e-c294463134be" xsi:type="Realization"/>
-    <relationship identifier="id-2ec1a30a-6556-4b3b-9214-d3ae726fed03" source="id-b3671631-d48f-45c4-934e-c294463134be" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-1ca7379b-7cf3-413f-9ae1-b2158e351a32" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-07d65b17-b7c5-4bc2-8c8e-9fe74f9d535a" xsi:type="Realization"/>
-    <relationship identifier="id-3c01183c-8959-4211-8afe-84b1154d4f40" source="id-07d65b17-b7c5-4bc2-8c8e-9fe74f9d535a" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-59ce9e4e-d6ee-4d7c-93ce-407a353d4918" source="id-73956421-5166-4390-8d3d-47cd1d27d7f9" target="id-1c8f07da-52c1-4c7b-b330-45c761d5df20" xsi:type="Realization"/>
-    <relationship identifier="id-ebdb21d0-3e17-4f8f-a2ac-24539a4ec22b" source="id-1c8f07da-52c1-4c7b-b330-45c761d5df20" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-e7a967bf-e630-4366-b7eb-91c5c50a0b07" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-805eaf8f-163c-4c08-998e-d4dada8e16a2" xsi:type="Realization"/>
-    <relationship identifier="id-ead9844d-a2cc-4830-8eb2-c9639cfb0087" source="id-805eaf8f-163c-4c08-998e-d4dada8e16a2" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-d9c84ced-e45d-4371-88a0-18b2cb941ef4" source="id-2f9db324-01c5-4fda-b132-1b7e5681a3c1" target="id-95b2a90d-1975-4a5d-9b0c-f53fa096592c" xsi:type="Realization"/>
-    <relationship identifier="id-e9e4a630-823a-417a-859a-4e1e0600234d" source="id-95b2a90d-1975-4a5d-9b0c-f53fa096592c" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-f029fdd7-66f6-4c84-8993-440e59701a7d" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-dc1efe1d-bcbe-469d-a6d3-29fecd8bbb6b" xsi:type="Realization"/>
-    <relationship identifier="id-a118ccfd-2e16-4ee5-8924-5a5d20d9a8db" source="id-dc1efe1d-bcbe-469d-a6d3-29fecd8bbb6b" target="id-cfb0984d-79c8-49b4-8ddc-28a1c6398e80" xsi:type="Access" accessType="Write"/>
-    <relationship identifier="id-7ae8479b-42f4-4068-a5f4-aec1249acc51" source="id-2986d0cc-ce48-4ae7-b0d9-03ce2825972b" target="id-b3671631-d48f-45c4-934e-c294463134be" xsi:type="Flow">
-      <name xml:lang="en">Order-to-Cash Flow: PawsPlus.com -&gt; Order Management System</name>
-    </relationship>
-    <relationship identifier="id-327717aa-e88c-452b-a678-c52decb2ee68" source="id-b3671631-d48f-45c4-934e-c294463134be" target="id-07d65b17-b7c5-4bc2-8c8e-9fe74f9d535a" xsi:type="Flow">
-      <name xml:lang="en">Order-to-Cash Flow: Order Management System -&gt; Inventory Service</name>
-    </relationship>
-    <relationship identifier="id-244da5cd-197b-4038-8241-09e0dd3e5a54" source="id-b3671631-d48f-45c4-934e-c294463134be" target="id-1c8f07da-52c1-4c7b-b330-45c761d5df20" xsi:type="Flow">
-      <name xml:lang="en">Order-to-Cash Flow: Order Management System -&gt; Payment Gateway</name>
-    </relationship>
-    <relationship identifier="id-0c57af96-fa29-494f-9dce-97712987625b" source="id-b3671631-d48f-45c4-934e-c294463134be" target="id-805eaf8f-163c-4c08-998e-d4dada8e16a2" xsi:type="Flow">
-      <name xml:lang="en">Order-to-Cash Flow: Order Management System -&gt; Warehouse Management System</name>
-    </relationship>
-    <relationship identifier="id-63f16d0c-10d9-41ab-9f77-24ef66c093b1" source="id-1c8f07da-52c1-4c7b-b330-45c761d5df20" target="id-95b2a90d-1975-4a5d-9b0c-f53fa096592c" xsi:type="Flow">
-      <name xml:lang="en">Order-to-Cash Flow: Payment Gateway -&gt; Settlement Engine</name>
-    </relationship>
-    <relationship identifier="id-a9816a41-db75-4af5-9df6-db1beca03848" source="id-95b2a90d-1975-4a5d-9b0c-f53fa096592c" target="id-dc1efe1d-bcbe-469d-a6d3-29fecd8bbb6b" xsi:type="Flow">
-      <name xml:lang="en">Order-to-Cash Flow: Settlement Engine -&gt; SAP ERP</name>
-    </relationship>
-    <relationship identifier="id-cd7b8e18-70a6-4e58-b2a2-b125efeea328" source="id-b5f56ed6-414a-44bf-adca-28556eda2ba4" target="id-002d4f5d-2094-49f9-9290-57284f792fb6" xsi:type="Realization"/>
-    <relationship identifier="id-05a69a5f-df6d-461c-a86e-7294a9951011" source="id-002d4f5d-2094-49f9-9290-57284f792fb6" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-762cb78a-eb4f-4d33-a21a-37606fa4b6f9" source="id-3f1510ed-493e-4bf5-8be4-a573ffd23c02" target="id-dbc07ccc-dffc-433e-a31f-ca8a56caf5ef" xsi:type="Realization"/>
-    <relationship identifier="id-027ee852-cb04-44b6-a1f4-e37922cbe28e" source="id-dbc07ccc-dffc-433e-a31f-ca8a56caf5ef" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-cce88ef7-37ce-4a9d-b3d0-a53aab5ca9a9" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-1d2cefb3-dc9e-46c0-a170-c35e61a27270" xsi:type="Realization"/>
-    <relationship identifier="id-3caa58fb-d7cc-4b2e-863a-e70e55d446a8" source="id-1d2cefb3-dc9e-46c0-a170-c35e61a27270" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-d0227eec-612c-41f2-a5d6-6d91b5db13fd" source="id-3fd12b95-60a9-4599-8a9f-f846320b8c3a" target="id-d8f12227-97a4-4979-ab40-6a5bf881d468" xsi:type="Realization"/>
-    <relationship identifier="id-9360bfb4-0de3-4ef0-86a7-ef1cbac9bbb7" source="id-d8f12227-97a4-4979-ab40-6a5bf881d468" target="id-0486c5c8-5d57-4af1-8cf8-5741cd86ef05" xsi:type="Access" accessType="Write"/>
-    <relationship identifier="id-71ebbe1c-b3d4-4a5a-8fb8-bd5a0ad4a503" source="id-002d4f5d-2094-49f9-9290-57284f792fb6" target="id-dbc07ccc-dffc-433e-a31f-ca8a56caf5ef" xsi:type="Flow">
-      <name xml:lang="en">Customer 360 Sync: Customer Hub -&gt; PawsPlus.com</name>
-    </relationship>
-    <relationship identifier="id-a1507b7f-d9f4-47fc-a21b-5610f08789cf" source="id-002d4f5d-2094-49f9-9290-57284f792fb6" target="id-1d2cefb3-dc9e-46c0-a170-c35e61a27270" xsi:type="Flow">
-      <name xml:lang="en">Customer 360 Sync: Customer Hub -&gt; CommsPlatform</name>
-    </relationship>
-    <relationship identifier="id-d5040b22-b508-4315-8db9-a3fcba2d81ce" source="id-002d4f5d-2094-49f9-9290-57284f792fb6" target="id-d8f12227-97a4-4979-ab40-6a5bf881d468" xsi:type="Flow">
-      <name xml:lang="en">Customer 360 Sync: Customer Hub -&gt; Enterprise Data Warehouse</name>
-    </relationship>
-    <relationship identifier="id-a147468f-88bb-4083-aafa-73ab26056d1b" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-d18dc771-1f39-4bc4-b754-9b6dc4d1bad9" xsi:type="Realization"/>
-    <relationship identifier="id-a5b57eaa-e04b-43a0-b5c1-394a3347b84e" source="id-d18dc771-1f39-4bc4-b754-9b6dc4d1bad9" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-b869c30c-1c0c-40ae-91d7-e74bba0b63f2" source="id-4b857da1-f068-4e50-ac08-1f9fb7a4d34d" target="id-f49d0a94-fbff-4a4b-bf3b-58b600d333d3" xsi:type="Realization"/>
-    <relationship identifier="id-ee51e0bf-0b8f-40e0-878a-93e46ec8715c" source="id-f49d0a94-fbff-4a4b-bf3b-58b600d333d3" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-8a233868-fb03-45ec-8e3d-4b3d02f792f6" source="id-6da69574-e14e-4505-a320-3b086578f026" target="id-6faa5ed8-a5c7-4d41-9357-6210ae2dfaa6" xsi:type="Realization"/>
-    <relationship identifier="id-4b36ddd5-2269-4431-bc53-045b0fc38ae1" source="id-6faa5ed8-a5c7-4d41-9357-6210ae2dfaa6" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-25cb5555-d80a-45a7-b226-55adc831fc19" source="id-b009b3f3-0fae-4a3e-aa6e-4061e15cef35" target="id-189848ff-4de2-4a2c-96e9-f4f476e9cb85" xsi:type="Realization"/>
-    <relationship identifier="id-41d8dd5e-f7f2-4233-8a4c-acef2a8d8ead" source="id-189848ff-4de2-4a2c-96e9-f4f476e9cb85" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-6ccae4df-0859-49a6-85e5-0dc30a9348a7" source="id-69217365-f468-43e6-a560-80a7b51fb83a" target="id-0de9eb59-0c4a-453e-9219-1b92640a5265" xsi:type="Realization"/>
-    <relationship identifier="id-6dbdb278-5074-4472-923d-321f8e9ddfea" source="id-0de9eb59-0c4a-453e-9219-1b92640a5265" target="id-1025a2b5-98f6-44ab-8bda-141f9838d11d" xsi:type="Access" accessType="Write"/>
-    <relationship identifier="id-b6944441-b993-4fde-852c-a20e860df39a" source="id-d18dc771-1f39-4bc4-b754-9b6dc4d1bad9" target="id-f49d0a94-fbff-4a4b-bf3b-58b600d333d3" xsi:type="Flow">
-      <name xml:lang="en">Inventory Replenishment Cycle: Warehouse Management System -&gt; Inventory Service</name>
-    </relationship>
-    <relationship identifier="id-b3b40471-0012-4d33-b89e-98eb258fc9ae" source="id-f49d0a94-fbff-4a4b-bf3b-58b600d333d3" target="id-6faa5ed8-a5c7-4d41-9357-6210ae2dfaa6" xsi:type="Flow">
-      <name xml:lang="en">Inventory Replenishment Cycle: Inventory Service -&gt; Demand Planner</name>
-    </relationship>
-    <relationship identifier="id-fb236f91-ef0e-4f9e-876b-9320ab0b78d7" source="id-6faa5ed8-a5c7-4d41-9357-6210ae2dfaa6" target="id-189848ff-4de2-4a2c-96e9-f4f476e9cb85" xsi:type="Flow">
-      <name xml:lang="en">Inventory Replenishment Cycle: Demand Planner -&gt; SAP ERP</name>
-    </relationship>
-    <relationship identifier="id-1cf2c9d3-6eda-43d4-8052-c8c1eb1607d5" source="id-189848ff-4de2-4a2c-96e9-f4f476e9cb85" target="id-0de9eb59-0c4a-453e-9219-1b92640a5265" xsi:type="Flow">
-      <name xml:lang="en">Inventory Replenishment Cycle: SAP ERP -&gt; Vendor Portal</name>
-    </relationship>
-    <relationship identifier="id-ca2df961-6da7-474c-a45f-1f30d7e1825b" source="id-4f061eb3-43dc-464a-8cd8-8b8e2b6371c0" target="id-18d086df-5eff-433f-b32a-d67a9a0514a6" xsi:type="Realization"/>
-    <relationship identifier="id-8617f7c4-17e0-44cd-9f39-1fc88996433a" source="id-18d086df-5eff-433f-b32a-d67a9a0514a6" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="Write"/>
-    <relationship identifier="id-6564c9a5-a596-484f-9e10-614a82cba650" source="id-73956421-5166-4390-8d3d-47cd1d27d7f9" target="id-e484cf55-2dc6-461e-aadd-53b5e93ccc21" xsi:type="Realization"/>
-    <relationship identifier="id-64e09cae-7e4a-4021-a66e-91c14890aba9" source="id-e484cf55-2dc6-461e-aadd-53b5e93ccc21" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-d9e3c31f-e41c-4f42-88db-1d2ce26ec11d" source="id-8b321e08-7e5e-4243-b386-e2fec7343dae" target="id-7c52ed74-8259-4b77-a101-65e36ab09f4a" xsi:type="Realization"/>
-    <relationship identifier="id-c2a7b1ca-36f9-4fff-a624-15aebc1a3034" source="id-7c52ed74-8259-4b77-a101-65e36ab09f4a" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-851d3c8a-ae01-4153-98f2-929660fb23ba" source="id-67d6b32b-850a-4c03-a64b-a646c5ca12fd" target="id-b6b14185-4b38-490c-8c27-fe7ceb799b8b" xsi:type="Realization"/>
-    <relationship identifier="id-0a903d67-07ba-4258-aa82-18ce8c4eed47" source="id-b6b14185-4b38-490c-8c27-fe7ceb799b8b" target="id-da353db5-7390-4e24-aa27-2cfd7e87af26" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-1b28b8d9-e991-4a5c-862b-8c33edccb3d7" source="id-18d086df-5eff-433f-b32a-d67a9a0514a6" target="id-e484cf55-2dc6-461e-aadd-53b5e93ccc21" xsi:type="Flow">
-      <name xml:lang="en">Subscription Autoship Pipeline: PawsCare+ Platform -&gt; Payment Gateway</name>
-    </relationship>
-    <relationship identifier="id-5e5b8579-ded3-4fc0-b6e3-4108b140bcde" source="id-18d086df-5eff-433f-b32a-d67a9a0514a6" target="id-7c52ed74-8259-4b77-a101-65e36ab09f4a" xsi:type="Flow">
-      <name xml:lang="en">Subscription Autoship Pipeline: PawsCare+ Platform -&gt; Order Management System</name>
-    </relationship>
-    <relationship identifier="id-709d9416-c11e-4ba4-94c7-25bd27fc5d8d" source="id-7c52ed74-8259-4b77-a101-65e36ab09f4a" target="id-b6b14185-4b38-490c-8c27-fe7ceb799b8b" xsi:type="Flow">
-      <name xml:lang="en">Subscription Autoship Pipeline: Order Management System -&gt; Warehouse Management System</name>
-    </relationship>
-    <relationship identifier="id-260d3bd0-6d41-4a14-b90a-0c15967cab98" source="id-313ffa6e-07ef-4b43-83c2-25dbb5f7cee8" target="id-727bfa7b-61c3-4216-911f-a9ee10d3462e" xsi:type="Realization"/>
-    <relationship identifier="id-06152b2d-e37c-4124-a479-3a619cdda6f2" source="id-727bfa7b-61c3-4216-911f-a9ee10d3462e" target="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-f34a8b1b-ca8f-47e7-b77f-47a5cd45dd39" source="id-cfda2874-f06f-4483-be75-828739e80a01" target="id-0d3ab860-a023-4583-b805-bd4d8e3c5ea8" xsi:type="Realization"/>
-    <relationship identifier="id-5c3a21a4-f94d-4e0c-ae53-44ff9725eefb" source="id-0d3ab860-a023-4583-b805-bd4d8e3c5ea8" target="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="Access" accessType="ReadWrite"/>
-    <relationship identifier="id-a26ea79f-eaef-4b0b-a47b-93cacb1c1653" source="id-f25f4333-7e93-47a7-9dd3-53066532ca0e" target="id-47aad289-34a5-494c-adb5-fd0abe0682f3" xsi:type="Realization"/>
-    <relationship identifier="id-3037db4b-dbdd-4b07-ad12-80ff7c6fdb0e" source="id-47aad289-34a5-494c-adb5-fd0abe0682f3" target="id-8197955a-dea9-4d57-a345-fb9e7e38de41" xsi:type="Access" accessType="Write"/>
-    <relationship identifier="id-3b0e660a-f389-4f0e-8b10-fbe08a11ecca" source="id-727bfa7b-61c3-4216-911f-a9ee10d3462e" target="id-0d3ab860-a023-4583-b805-bd4d8e3c5ea8" xsi:type="Flow">
-      <name xml:lang="en">Prescription Fulfillment Flow: VetConnect -&gt; RxManager</name>
-    </relationship>
-    <relationship identifier="id-544c42e3-2794-4bac-9245-071b45bd775a" source="id-0d3ab860-a023-4583-b805-bd4d8e3c5ea8" target="id-47aad289-34a5-494c-adb5-fd0abe0682f3" xsi:type="Flow">
-      <name xml:lang="en">Prescription Fulfillment Flow: RxManager -&gt; CommsPlatform</name>
-    </relationship>
-  </relationships>
 </model>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "etcion"
-version = "0.5.0"
+version = "0.5.1"
 description = "Architecture as code — build, query, validate, and analyze enterprise architecture models in Python"
 readme = "README.md"
 license = "MIT"

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -46,6 +46,9 @@ _XSD_TO_PY_TYPE: dict[str, type] = {
     "boolean": bool,
 }
 
+# Well-known propertyDefinition identifier for the specialization field.
+_SPECIALIZATION_PROPDEF_ID = "propdef-specialization"
+
 
 def _to_exchange_id(internal_id: str) -> str:
     """Wrap bare UUID as ``id-{uuid}``; pass through if already prefixed."""
@@ -68,18 +71,25 @@ def serialize_element(elem: Element) -> etree._Element:
         doc_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
         doc_el.text = elem.description
 
-    if elem.specialization:
-        el.set("specialization", elem.specialization)
-
-    if elem.extended_attributes:
+    has_props = bool(elem.specialization or elem.extended_attributes)
+    if has_props:
         props_container = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}properties")
-        type_name = TYPE_REGISTRY[type(elem)].xml_tag
-        for attr_name, value in elem.extended_attributes.items():
+
+        if elem.specialization:
             prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
-            prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+            prop_el.set("propertyDefinitionRef", _SPECIALIZATION_PROPDEF_ID)
             val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
             val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
-            val_el.text = str(value)
+            val_el.text = elem.specialization
+
+        if elem.extended_attributes:
+            type_name = TYPE_REGISTRY[type(elem)].xml_tag
+            for attr_name, value in elem.extended_attributes.items():
+                prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
+                prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+                val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
+                val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+                val_el.text = str(value)
 
     return el
 
@@ -116,19 +126,6 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
     name_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
     name_el.text = model_name
 
-    if model.profiles:
-        propdefs = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}propertyDefinitions")
-        for profile in model.profiles:
-            for cls, attrs in profile.attribute_extensions.items():
-                type_name = TYPE_REGISTRY[cls].xml_tag
-                for attr_name, attr_type in attrs.items():
-                    pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
-                    pd.set("identifier", f"propdef-{type_name}-{attr_name}")
-                    pd.set("type", _PY_TO_XSD_TYPE.get(attr_type.__name__, "string"))
-                    pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
-                    pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
-                    pd_name.text = attr_name
-
     elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
     for elem in model.elements:
         elements_container.append(serialize_element(elem))
@@ -140,6 +137,60 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
     opaque = getattr(model, "_opaque_xml", [])
     for node in opaque:
         root.append(node)
+
+    # XSD requires <propertyDefinitions> after elements, relationships, and
+    # organizations (see ModelType in archimate3_Model.xsd).
+    # Collect every propdef identifier actually referenced by elements so that
+    # no dangling propertyDefinitionRef values remain.
+    has_specializations = any(e.specialization for e in model.elements)
+
+    # Build set of profile-declared propdef ids and collect all element refs.
+    declared_ids: set[str] = set()
+    for profile in model.profiles:
+        for cls, attrs in profile.attribute_extensions.items():
+            type_name = TYPE_REGISTRY[cls].xml_tag
+            for attr_name in attrs:
+                declared_ids.add(f"propdef-{type_name}-{attr_name}")
+
+    # Discover undeclared extended attributes on elements.
+    undeclared: dict[str, str] = {}  # propdef_id -> attr_name
+    for elem in model.elements:
+        if elem.extended_attributes:
+            type_name = TYPE_REGISTRY[type(elem)].xml_tag
+            for attr_name in elem.extended_attributes:
+                pid = f"propdef-{type_name}-{attr_name}"
+                if pid not in declared_ids:
+                    undeclared[pid] = attr_name
+
+    if has_specializations or declared_ids or undeclared:
+        propdefs = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+
+        if has_specializations:
+            pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
+            pd.set("identifier", _SPECIALIZATION_PROPDEF_ID)
+            pd.set("type", "string")
+            pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
+            pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+            pd_name.text = "specialization"
+
+        for profile in model.profiles:
+            for cls, attrs in profile.attribute_extensions.items():
+                type_name = TYPE_REGISTRY[cls].xml_tag
+                for attr_name, attr_type in attrs.items():
+                    pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
+                    pd.set("identifier", f"propdef-{type_name}-{attr_name}")
+                    pd.set("type", _PY_TO_XSD_TYPE.get(attr_type.__name__, "string"))
+                    pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
+                    pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+                    pd_name.text = attr_name
+
+        for pid, attr_name in undeclared.items():
+            pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
+            pd.set("identifier", pid)
+            pd.set("type", "string")
+            pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
+            pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+            pd_name.text = attr_name
 
     return etree.ElementTree(root)
 
@@ -190,14 +241,18 @@ def _deserialize_element(
     doc_node = node.find(f"{{{ARCHIMATE_NS}}}documentation")
     desc: str | None = doc_node.text if doc_node is not None else None
 
-    specialization: str | None = node.get("specialization")
+    specialization: str | None = None
     extended_attributes: dict[str, Any] = {}
     props_node = node.find(f"{{{ARCHIMATE_NS}}}properties")
-    if props_node is not None and propdef_map:
+    if props_node is not None:
         for prop_node in props_node:
             ref = prop_node.get("propertyDefinitionRef", "")
             val_node = prop_node.find(f"{{{ARCHIMATE_NS}}}value")
-            if ref in propdef_map and val_node is not None and val_node.text:
+            if val_node is None or not val_node.text:
+                continue
+            if ref == _SPECIALIZATION_PROPDEF_ID:
+                specialization = val_node.text
+            elif propdef_map and ref in propdef_map:
                 attr_name, attr_type = propdef_map[ref]
                 extended_attributes[attr_name] = attr_type(val_node.text)
 

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -654,7 +654,7 @@ class TestProfileXmlSerialization:
         root = self._root(profiled_model)
         pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
         assert pd_container is not None
-        assert len(pd_container) == 2  # region + cost
+        assert len(pd_container) == 3  # specialization + region + cost
 
     def test_property_definition_has_identifier(self, profiled_model: Model) -> None:
         root = self._root(profiled_model)
@@ -687,12 +687,20 @@ class TestProfileXmlSerialization:
         assert type_by_id["propdef-ApplicationComponent-region"] == "string"
         assert type_by_id["propdef-ApplicationComponent-cost"] == "number"
 
-    def test_element_has_specialization_attr(self, profiled_model: Model) -> None:
+    def test_element_has_specialization_property(self, profiled_model: Model) -> None:
         root = self._root(profiled_model)
         elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
         assert elements_node is not None
-        specializations = [el.get("specialization") for el in elements_node]
-        assert "Microservice" in specializations
+        spec_values: list[str] = []
+        for el in elements_node:
+            props = el.find(f"{{{ARCHIMATE_NS}}}properties")
+            if props is not None:
+                for prop in props:
+                    if prop.get("propertyDefinitionRef") == "propdef-specialization":
+                        val = prop.find(f"{{{ARCHIMATE_NS}}}value")
+                        if val is not None and val.text:
+                            spec_values.append(val.text)
+        assert "Microservice" in spec_values
 
     def test_element_has_properties(self, profiled_model: Model) -> None:
         root = self._root(profiled_model)
@@ -709,7 +717,7 @@ class TestProfileXmlSerialization:
         for el in elements_node:
             props = el.find(f"{{{ARCHIMATE_NS}}}properties")
             assert props is not None
-            assert len(props) == 2, f"Expected 2 properties, got {len(props)}"
+            assert len(props) == 3
 
     def test_element_property_has_value(self, profiled_model: Model) -> None:
         root = self._root(profiled_model)
@@ -724,12 +732,13 @@ class TestProfileXmlSerialization:
                 assert val_node.text is not None and val_node.text != ""
 
     def test_element_no_specialization_when_none(self, simple_model: Model) -> None:
-        # simple_model has no profiles; elements must not carry specialization attr
+        # simple_model has no profiles; elements must not carry specialization property
         root = serialize_model(simple_model).getroot()
         elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
         assert elements_node is not None
         for el in elements_node:
-            assert el.get("specialization") is None
+            props = el.find(f"{{{ARCHIMATE_NS}}}properties")
+            assert props is None
 
 
 class TestProfileXmlRoundTrip:
@@ -798,7 +807,6 @@ class TestProfileXmlRoundTripIntegrity:
             strict=True,
         ):
             assert e1.get(f"{{{XSI_NS}}}type") == e2.get(f"{{{XSI_NS}}}type")
-            assert e1.get("specialization") == e2.get("specialization")
             # Compare property values
             props1 = e1.find(f"{{{ARCHIMATE_NS}}}properties")
             props2 = e2.find(f"{{{ARCHIMATE_NS}}}properties")

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -19,7 +19,7 @@ class TestVersionExposed:
     """etcion.__version__ is publicly accessible and correct."""
 
     def test_version_exposed(self) -> None:
-        assert etcion.__version__ == "0.5.0"
+        assert etcion.__version__ == "0.5.1"
 
     def test_version_is_string(self) -> None:
         assert isinstance(etcion.__version__, str)

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -69,7 +69,7 @@ class TestProjectMetadata:
 
     def test_project_version(self) -> None:
         data = _load_toml()
-        assert data["project"]["version"] == "0.5.0"
+        assert data["project"]["version"] == "0.5.1"
 
     def test_requires_python(self) -> None:
         data = _load_toml()


### PR DESCRIPTION
## Fixes
                                                                                                                                                                                                                                                         
- Property type mapping: \`real\`/\`integer\` → \`number\` per XSD enumeration                                                                                                                                                                         
- Element ordering: \`<propertyDefinitions>\` moved after elements/relationships per ModelType sequence                                                                                                                                                
- Specialization: serialized as \`<property>\` instead of invalid XML attribute                                                                                                                                                                         - Dangling property refs: emit definitions for all extended attributes, not just profile-declared ones                                                                                                                                               
- Petco example: Assignment → Composition for AppComponent → AppInterface                                                                                                                                                                              
                                                                                                                                                                                                                                                         
Validated with Archi import — zero errors. 