### PR TITLE
Lift extended_attributes from Element to Concept (#100, ADR-050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Behavior changes
+
+- **`extended_attributes` lifted from `Element` to `Concept`** (closes #100).
+  Relationships and connectors (Junction) can now carry profile-declared
+  extended attributes -- including provenance keys -- in the same way
+  elements do. `Element.extended_attributes` callers continue to work
+  unchanged; the field is now inherited from one level up. `Profile`'s
+  `attribute_extensions` keys broadened from `Element` to `Concept`;
+  `specializations` keys remain `Element`-only. `Model.validate()` now
+  walks all concepts when checking extended-attribute conformance.
+  Relationship `<properties>` round-trip cleanly through XML. See
+  [ADR-050](docs/adr/ADR-050-extended-attributes-on-concept.md).
+
+  Note: relationship-level `<properties>` written by etcion >= 0.12 cannot
+  be deserialized by older versions; extended-attribute data on
+  relationships is silently dropped on re-export by older readers.
+
+### Added
+
+- Concept-wide provenance helpers: `unreviewed_concepts`,
+  `concepts_by_source`, `low_confidence_concepts`. The element-scoped
+  helpers (`unreviewed_elements`, etc.) preserve their `list[Element]`
+  return contract unchanged.
+
+### Fixed
+
+- XML round-trip of `bool` extended attributes was previously broken
+  because `bool("False")` is `True`. The deserializer now coerces
+  bool values via case-insensitive string comparison.
+
 ## [0.11.1] - 27 Apr 2026
 
 ### Behavior changes

--- a/docs/adr/ADR-050-extended-attributes-on-concept.md
+++ b/docs/adr/ADR-050-extended-attributes-on-concept.md
@@ -1,0 +1,50 @@
+# ADR-050: extended_attributes lifted from Element to Concept
+
+**Status:** ACCEPTED
+**Date:** 2026-04-27
+**Scope:** Pydantic surface of `etcion.metamodel.concepts.Concept` and ripple effects through Profile validation, `Model.validate()`, XML serialization, and provenance helpers.
+
+## Context
+
+Until v0.11.x, `extended_attributes: dict[str, Any]` lived on `Element` only. Relationships and Junctions -- both first-class `Concept` subclasses in the ArchiMate 3.2 metamodel and both legitimate carriers of `<properties>` per the Exchange Format XSD -- could not carry user-defined or profile-driven extended attributes. Downstream callers worked around this by stashing per-relationship metadata in side-channel dicts keyed on relationship `id`, which:
+
+- bypassed `Profile` validation entirely,
+- was lost on XML round-trip because `serialize_relationship` had no `<properties>` emit path,
+- forced `Model.validate()` to skip half the model when checking profile-conformance.
+
+The ArchiMate Exchange Format XSD permits `<properties>` on every concept (element, relationship, and junction alike), so the field's placement on `Element` was inconsistent with the format we serialize to. ADR-049 set the precedent for this kind of correction: align the Pydantic surface with what the spec already allows, but only where the spec actually demands it -- do not over-symmetrize.
+
+Link: #100, see also ADR-049 (symmetry-only-where-spec-demands-it precedent), ADR-008 (`AttributeMixin` pattern).
+
+## Decision
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Lift `extended_attributes: dict[str, Any] = Field(default_factory=dict)` from `Element` to `Concept` | Concept is the narrowest base that covers Element, Relationship, and Junction. Lifting here picks up all three in one move and matches the XSD scope of `<properties>`. |
+| 2 | Do **not** lift to `AttributeMixin` | `AttributeMixin` carries *descriptive* attributes (`name`, `documentation`). `extended_attributes` is a profile/property bag, not a descriptive field; mixing them muddies ADR-008. `AttributeMixin` is also wider than Concept (Connector inherits it) which would over-broaden the surface. |
+| 3 | Relax `Profile._validate_profile` so `attribute_extensions` accepts any `Concept` subclass key | A profile that types relationships needs to constrain relationship extended attributes; restricting keys to `Element` made profiles unable to validate the very fields we now permit. |
+| 4 | Keep `Profile.specializations` keyed on `Element` only | Specialization in ArchiMate 3.2 is defined for elements; relationships have their own derivation rules and junctions are structural. Broadening `specializations` would invent semantics the spec does not. |
+| 5 | Extend `Model.validate()` to walk all concepts, not just elements, when checking extended-attribute conformance | The validation pass must mirror the storage scope; otherwise invalid attribute values on relationships pass silently. |
+| 6 | Add a `<properties>` emit path on `serialize_relationship` mirroring the Element path; update the propdef-discovery loop in `serialize_model` to walk relationships as well | XML round-trip is non-negotiable; without this the lift is invisible on disk. The propdef discovery loop must see relationship keys to emit a complete `<propertyDefinitions>` section. |
+| 7 | Defer Junction `<properties>` XML round-trip to a follow-up | Connector serialization for Junction is opaque today (no `<properties>` emit, no propdef discovery). In-scope for v1 is Relationship XML round-trip; Junction parity is tracked separately to keep this PR reviewable. The Pydantic field is still present on Junction, so in-memory and JSON paths work immediately. |
+| 8 | Keep `INGESTION_PROFILE` element-keyed | Provenance ingestion in practice tags elements; broadening the default profile to all concepts would force every existing ingestion run to start emitting relationship-level provenance keys whether they want to or not. Module docstring documents how to construct a relationship-targeted provenance profile for callers who need one. |
+| 9 | Split provenance helpers: keep `unreviewed_elements` Element-scoped; add `unreviewed_concepts` that walks elements, relationships, and junctions | Preserves the existing helper's contract (callers expect `Element` instances back) while giving new callers a concept-wide sweep. Avoids a silent return-type change. |
+
+## Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| Lift `extended_attributes` to `AttributeMixin` (Element + Relationship) | `AttributeMixin` does not cover Junction (Junction is a `Concept` but has no `name`/`documentation`), so this misses one of the three concept kinds the XSD permits. Also conflates descriptive attributes with property bags -- see ADR-008. |
+| Add `extended_attributes` only to `Relationship` and leave `Junction` without | Junction is a first-class Concept under the spec and can carry `<properties>` in the Exchange Format. Excluding it perpetuates the inconsistency we are fixing. |
+| Keep the current state and let downstream code use a side-channel `dict[rel_id, dict]` | This is the workaround the bug report describes. It bypasses Profile validation, loses data on XML round-trip, and pushes the same problem onto every adapter (CSV, Parquet, DuckDB). Not a fix. |
+| Broaden `INGESTION_PROFILE` to all concepts as the default | Forces relationship-level provenance keys onto every existing ingestion pipeline. Capability should be opt-in: the lift gives callers the *ability* to do this; the default profile should not silently start doing it for them. |
+
+## Consequences
+
+- **Public Python API: purely additive.** `Element.extended_attributes` callers continue to work unchanged (the field is still present, just inherited from one level up). `Relationship.extended_attributes` and `Junction.extended_attributes` become available; nothing existing breaks.
+- **XML wire-format: forward-compat break.** Files written by etcion >= 0.12 that contain relationship-level `<properties>` cannot be deserialized by etcion < 0.12 -- the older parser ignores the element silently and the data is lost on re-serialize. This is documented as a one-way upgrade in the CHANGELOG.
+- **ADR-008 (AttributeMixin pattern) is unaffected.** `extended_attributes` is not a descriptive attribute and was never a candidate for that mixin. The mixin's contract -- "fields that describe the concept to a human reader" -- is preserved.
+- **Profile authoring surface widens.** Profiles can now declare `attribute_extensions` keyed on any `Concept` subclass. `specializations` deliberately stays Element-only; profile authors who try to specialize a `Relationship` will get the same `ValidationError` they get today.
+- **`Model.validate()` cost grows linearly with relationship count** when profiles declare relationship-level extensions. For typical models (relationships outnumber elements ~3:1) this is the expected scale and remains O(n).
+- **CHANGELOG entry required** under a "Behavior changes" heading: note the field lift, the relaxed Profile key constraint, the new XML emit path, the deferred Junction XML follow-up, and the new `unreviewed_concepts` helper alongside the unchanged `unreviewed_elements`.
+- **Junction XML parity is a known gap.** Tracked as a follow-up issue; in-memory and non-XML serializers handle Junction extended attributes correctly from day one.

--- a/src/etcion/__init__.py
+++ b/src/etcion/__init__.py
@@ -197,10 +197,14 @@ from etcion.metamodel.viewpoint_catalogue import VIEWPOINT_CATALOGUE, ViewpointC
 from etcion.metamodel.viewpoints import Concern, View, Viewpoint
 
 # Phase 8: Built-in provenance metadata profile and query helpers (Issues #25, #26)
+# Concept-wide counterparts added in Issue #100 (ADR-050).
 from etcion.provenance import (
     INGESTION_PROFILE,
+    concepts_by_source,
     elements_by_source,
+    low_confidence_concepts,
     low_confidence_elements,
+    unreviewed_concepts,
     unreviewed_elements,
 )
 from etcion.serialization.graph_data import (
@@ -380,11 +384,15 @@ __all__: list[str] = [
     "MergeResult",
     "merge_models",
     "apply_diff",
-    # Built-in provenance metadata profile and query helpers (Issues #25, #26)
+    # Built-in provenance metadata profile and query helpers (Issues #25, #26).
+    # Concept-wide counterparts added in Issue #100 (ADR-050).
     "INGESTION_PROFILE",
     "unreviewed_elements",
     "elements_by_source",
     "low_confidence_elements",
+    "unreviewed_concepts",
+    "concepts_by_source",
+    "low_confidence_concepts",
     # Graph metadata export helpers (ADR-047, Issue #38; covers #45, #46, #47)
     "ELEMENT_ICONS",
     "LAYER_COLORS",

--- a/src/etcion/metamodel/concepts.py
+++ b/src/etcion/metamodel/concepts.py
@@ -50,6 +50,20 @@ class Concept(abc.ABC, BaseModel):
     is accepted to support Archi-prefixed IDs (e.g. ``id-<uuid>``) and plain
     UUID strings from the Open Group Exchange Format."""
 
+    extended_attributes: dict[str, Any] = Field(default_factory=dict)
+    """Arbitrary extended attributes declared by a
+    :class:`~etcion.metamodel.profiles.Profile`.
+
+    Available on every :class:`Concept` subclass -- elements, relationships,
+    and connectors -- so that profile-declared attributes (including
+    provenance keys) can attach to any concept.  Keys are attribute names;
+    values are profile-declared data of any type.  Type checking against the
+    profile's ``attribute_extensions`` schema is performed by
+    :meth:`~etcion.metamodel.model.Model.validate`.
+
+    Reference: ADR-050.
+    """
+
     @property
     @abstractmethod
     def _type_name(self) -> str:
@@ -82,15 +96,6 @@ class Element(AttributeMixin, Concept):
     type, as declared by a :class:`~etcion.metamodel.profiles.Profile`.
     Validation against a registered profile is performed by
     ``Model.validate()``.
-    """
-
-    extended_attributes: dict[str, Any] = Field(default_factory=dict)
-    """Arbitrary extended attributes declared by a
-    :class:`~etcion.metamodel.profiles.Profile`.
-
-    Keys are attribute names; values are profile-declared data of any type.
-    Type checking against the profile's ``attribute_extensions`` schema is
-    performed by ``Model.validate()``.
     """
 
 

--- a/src/etcion/metamodel/model.py
+++ b/src/etcion/metamodel/model.py
@@ -345,43 +345,54 @@ class Model:
                             raise err
                         errors.append(err)
 
-        # FEAT-18.3: Profile validation.
-        for elem in self.elements:
-            # Check specialization string
-            if elem.specialization is not None:
-                if elem.specialization not in self._specialization_registry:
+        # FEAT-18.3 / ADR-050: Profile validation.
+        # Specialization is Element-only; extended_attributes apply to every Concept.
+        from etcion.metamodel.profiles import AttributeConstraint
+
+        for concept in self._concepts.values():
+            # Build a typed label for error messages: "Element", "Relationship",
+            # or the connector class name (e.g. "Junction").
+            if isinstance(concept, Element):
+                label = "Element"
+            elif isinstance(concept, Relationship):
+                label = "Relationship"
+            else:
+                label = type(concept).__name__
+
+            # Specialization is Element-only -- relationships and connectors
+            # do not specialize per ArchiMate 3.2.
+            if isinstance(concept, Element) and concept.specialization is not None:
+                if concept.specialization not in self._specialization_registry:
                     err = ValidationError(
-                        f"Element '{elem.id}': specialization "
-                        f"'{elem.specialization}' is not declared in any profile"
+                        f"Element '{concept.id}': specialization "
+                        f"'{concept.specialization}' is not declared in any profile"
                     )
                     if strict:
                         raise err
                     errors.append(err)
                 else:
-                    expected_base = self._specialization_registry[elem.specialization]
-                    if not isinstance(elem, expected_base):
+                    expected_base = self._specialization_registry[concept.specialization]
+                    if not isinstance(concept, expected_base):
                         err = ValidationError(
-                            f"Element '{elem.id}': specialization "
-                            f"'{elem.specialization}' requires base type "
-                            f"{expected_base.__name__}, got {type(elem).__name__}"
+                            f"Element '{concept.id}': specialization "
+                            f"'{concept.specialization}' requires base type "
+                            f"{expected_base.__name__}, got {type(concept).__name__}"
                         )
                         if strict:
                             raise err
                         errors.append(err)
 
-            # Check extended_attributes against profile declarations
-            # Build the constraint map for this element type from all profiles.
-            from etcion.metamodel.profiles import AttributeConstraint
-
+            # Check extended_attributes against profile declarations.
+            # Per ADR-050, this loop runs for elements, relationships, and connectors.
             declared_constraints: dict[str, AttributeConstraint] = {}
             for prof in self._profiles:
-                declared_constraints.update(prof.get_constraints(type(elem)))
+                declared_constraints.update(prof.get_constraints(type(concept)))
 
-            # Check undeclared attributes (present on element but not in any profile).
-            for attr_name in elem.extended_attributes:
+            # Check undeclared attributes (present on concept but not in any profile).
+            for attr_name in concept.extended_attributes:
                 if attr_name not in declared_constraints:
                     err = ValidationError(
-                        f"Element '{elem.id}': extended attribute "
+                        f"{label} '{concept.id}': extended attribute "
                         f"'{attr_name}' is not declared in any profile"
                     )
                     if strict:
@@ -390,12 +401,12 @@ class Model:
 
             # Check declared constraints against actual attribute values.
             for attr_name, constraint in declared_constraints.items():
-                attr_value = elem.extended_attributes.get(attr_name)
+                attr_value = concept.extended_attributes.get(attr_name)
 
                 # required: attribute must be present and non-None.
                 if constraint.required and attr_value is None:
                     err = ValidationError(
-                        f"Element '{elem.id}': extended attribute "
+                        f"{label} '{concept.id}': extended attribute "
                         f"'{attr_name}' is required but missing"
                     )
                     if strict:
@@ -410,7 +421,7 @@ class Model:
                 # type check
                 if not isinstance(attr_value, constraint.attr_type):
                     err = ValidationError(
-                        f"Element '{elem.id}': extended attribute "
+                        f"{label} '{concept.id}': extended attribute "
                         f"'{attr_name}' expected type "
                         f"{constraint.attr_type.__name__}, "
                         f"got {type(attr_value).__name__}"
@@ -423,7 +434,7 @@ class Model:
                 # allowed list check
                 if constraint.allowed is not None and attr_value not in constraint.allowed:
                     err = ValidationError(
-                        f"Element '{elem.id}': extended attribute "
+                        f"{label} '{concept.id}': extended attribute "
                         f"'{attr_name}' value {attr_value!r} is not in the "
                         f"allowed list {constraint.allowed!r}"
                     )
@@ -441,7 +452,7 @@ class Model:
                         below_min = False
                     if below_min:
                         err = ValidationError(
-                            f"Element '{elem.id}': extended attribute "
+                            f"{label} '{concept.id}': extended attribute "
                             f"'{attr_name}' value {attr_value!r} is below "
                             f"min {constraint.min!r}"
                         )
@@ -456,7 +467,7 @@ class Model:
                         above_max = False
                     if above_max:
                         err = ValidationError(
-                            f"Element '{elem.id}': extended attribute "
+                            f"{label} '{concept.id}': extended attribute "
                             f"'{attr_name}' value {attr_value!r} is above "
                             f"max {constraint.max!r}"
                         )

--- a/src/etcion/metamodel/profiles.py
+++ b/src/etcion/metamodel/profiles.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from etcion.metamodel.concepts import Element
+from etcion.metamodel.concepts import Concept, Element
 
 # ---------------------------------------------------------------------------
 # Recognized constraint keys (besides "type")
@@ -174,43 +174,54 @@ class Profile(BaseModel):
     def _validate_profile(self) -> "Profile":
         """Enforce key and field-name integrity rules at construction time.
 
-        Rule 1: every key in ``specializations`` and ``attribute_extensions``
-        must be a subclass of :class:`~etcion.metamodel.concepts.Element`.
+        Rule 1a: every key in ``specializations`` must be a subclass of
+        :class:`~etcion.metamodel.concepts.Element`.  Specialization is an
+        Element-layer feature in ArchiMate 3.2; relationships and connectors
+        are not specializable.
 
-        Rule 2: every attribute name declared in ``attribute_extensions`` must
-        not collide with an existing Pydantic field on the target element type.
+        Rule 1b (ADR-050): every key in ``attribute_extensions`` must be a
+        subclass of :class:`~etcion.metamodel.concepts.Concept`.  Profiles
+        may declare extended attributes for elements, relationships, and
+        connectors alike.
+
+        Rule 2: every attribute name declared in ``attribute_extensions``
+        must not collide with an existing Pydantic field on the target
+        concept type.
 
         Rule 3 (Issue #52): every value in ``attribute_extensions`` must be
-        either a bare ``type`` or a constraint dict with recognized keys; the
-        dict is validated by :func:`resolve_constraint`.
+        either a bare ``type`` or a constraint dict with recognized keys;
+        the dict is validated by :func:`resolve_constraint`.
         """
-        # Rule 1: all keys must be Element subclasses.
-        for mapping_name in ("specializations", "attribute_extensions"):
-            mapping: dict[Any, Any] = getattr(self, mapping_name)
-            for key in mapping:
-                if not (isinstance(key, type) and issubclass(key, Element)):
-                    raise ValueError(f"{mapping_name} key {key!r} is not a subclass of Element")
+        # Rule 1a: specializations keys must be Element subclasses.
+        for key in self.specializations:
+            if not (isinstance(key, type) and issubclass(key, Element)):
+                raise ValueError(f"specializations key {key!r} is not a subclass of Element")
+
+        # Rule 1b (ADR-050): attribute_extensions keys must be Concept subclasses.
+        for key in self.attribute_extensions:
+            if not (isinstance(key, type) and issubclass(key, Concept)):
+                raise ValueError(f"attribute_extensions key {key!r} is not a subclass of Concept")
 
         # Rule 2: no field name conflicts in attribute_extensions.
         # Rule 3: validate constraint dicts and normalize to AttributeConstraint.
         normalized: dict[Any, dict[str, AttributeConstraint]] = {}
-        for elem_type, attrs in self.attribute_extensions.items():
-            existing: set[str] = set(elem_type.model_fields)
+        for concept_type, attrs in self.attribute_extensions.items():
+            existing: set[str] = set(concept_type.model_fields)
             resolved_attrs: dict[str, AttributeConstraint] = {}
             for attr_name, raw_value in attrs.items():
                 if attr_name in existing:
                     raise ValueError(
                         f"attribute_extensions: '{attr_name}' conflicts with "
-                        f"existing field on {elem_type.__name__}"
+                        f"existing field on {concept_type.__name__}"
                     )
                 try:
                     constraint = resolve_constraint(raw_value)
                 except ValueError as exc:
                     raise ValueError(
-                        f"attribute_extensions[{elem_type.__name__}]['{attr_name}']: {exc}"
+                        f"attribute_extensions[{concept_type.__name__}]['{attr_name}']: {exc}"
                     ) from exc
                 resolved_attrs[attr_name] = constraint
-            normalized[elem_type] = resolved_attrs
+            normalized[concept_type] = resolved_attrs
 
         # Store normalized constraints as an instance attribute.
         # We bypass Pydantic's __setattr__ by using object.__setattr__ since the
@@ -219,21 +230,22 @@ class Profile(BaseModel):
 
         return self
 
-    def get_constraints(self, elem_type: type[Element]) -> dict[str, AttributeConstraint]:
-        """Return the normalized :class:`AttributeConstraint` map for *elem_type*.
+    def get_constraints(self, concept_type: type[Concept]) -> dict[str, AttributeConstraint]:
+        """Return the normalized :class:`AttributeConstraint` map for *concept_type*.
 
-        Returns all constraints declared for *elem_type* in this profile,
+        Returns all constraints declared for *concept_type* in this profile,
         including those inherited through ``isinstance`` matching (i.e., if
-        the profile declares constraints for a parent type and *elem_type*
+        the profile declares constraints for a parent type and *concept_type*
         is a subclass, this method returns those constraints).
 
-        :param elem_type: A concrete :class:`~etcion.metamodel.concepts.Element`
-            subclass to look up.
+        :param concept_type: A concrete :class:`~etcion.metamodel.concepts.Concept`
+            subclass to look up.  Per ADR-050, this may be an Element,
+            Relationship, or RelationshipConnector subclass.
         :returns: Dict mapping attribute name to :class:`AttributeConstraint`.
             An empty dict is returned if no declarations match.
         """
         result: dict[str, AttributeConstraint] = {}
         for declared_type, constraints in self._constraints.items():
-            if issubclass(elem_type, declared_type):
+            if issubclass(concept_type, declared_type):
                 result.update(constraints)
         return result

--- a/src/etcion/provenance.py
+++ b/src/etcion/provenance.py
@@ -26,12 +26,48 @@ Example::
     model.add(actor)
     assert model.validate() == []
 
-Reference: GitHub Issue #25.
+Provenance on relationships and connectors
+------------------------------------------
+
+Per ADR-050, ``extended_attributes`` are available on every
+:class:`~etcion.metamodel.concepts.Concept` -- including relationships and
+junctions -- so that synthesized edges (e.g. from cloud resource graph
+connectors) can carry provenance metadata.
+
+``INGESTION_PROFILE`` keys on :class:`~etcion.metamodel.concepts.Element` only
+because the common ingestion case tags elements; broadening the default would
+force every existing pipeline to start emitting relationship-level keys.
+Callers who need relationship-level provenance should construct their own
+profile re-using the same attribute names::
+
+    from etcion.metamodel.relationships import Relationship
+    from etcion.metamodel.profiles import Profile
+
+    REL_INGESTION_PROFILE = Profile(
+        name="IngestionMetadata-Relationships",
+        attribute_extensions={
+            Relationship: {
+                "_provenance_source": str,
+                "_provenance_confidence": float,
+                "_provenance_reviewed": bool,
+                "_provenance_timestamp": str,
+            },
+        },
+    )
+
+The element-scoped helpers (:func:`unreviewed_elements`,
+:func:`elements_by_source`, :func:`low_confidence_elements`) preserve their
+``list[Element]`` return contract.  Use the corresponding ``*_concepts``
+counterparts (:func:`unreviewed_concepts`, :func:`concepts_by_source`,
+:func:`low_confidence_concepts`) for sweeps that include relationships and
+connectors.
+
+Reference: GitHub Issue #25; GitHub Issue #100; ADR-050.
 """
 
 from __future__ import annotations
 
-from etcion.metamodel.concepts import Element
+from etcion.metamodel.concepts import Concept, Element
 from etcion.metamodel.model import Model
 from etcion.metamodel.profiles import Profile
 
@@ -40,6 +76,9 @@ __all__: list[str] = [
     "unreviewed_elements",
     "elements_by_source",
     "low_confidence_elements",
+    "unreviewed_concepts",
+    "concepts_by_source",
+    "low_confidence_concepts",
 ]
 
 INGESTION_PROFILE: Profile = Profile(
@@ -79,9 +118,9 @@ Declares four extended attributes on all
 # ---------------------------------------------------------------------------
 
 
-def _has_provenance(elem: Element) -> bool:
-    """Return True if *elem* carries at least one ``_provenance_*`` attribute."""
-    return any(k.startswith("_provenance_") for k in elem.extended_attributes)
+def _has_provenance(concept: Concept) -> bool:
+    """Return True if *concept* carries at least one ``_provenance_*`` attribute."""
+    return any(k.startswith("_provenance_") for k in concept.extended_attributes)
 
 
 # ---------------------------------------------------------------------------
@@ -148,4 +187,66 @@ def low_confidence_elements(model: Model, threshold: float = 0.5) -> list[Elemen
         if _has_provenance(e)
         and isinstance(e.extended_attributes.get("_provenance_confidence"), (int, float))
         and e.extended_attributes["_provenance_confidence"] < threshold
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Concept-wide query helpers (Issue #100 / ADR-050)
+# ---------------------------------------------------------------------------
+
+
+def unreviewed_concepts(model: Model) -> list[Concept]:
+    """Return concepts that have provenance metadata but are not yet reviewed.
+
+    Walks every :class:`~etcion.metamodel.concepts.Concept` in *model* --
+    elements, relationships, and connectors -- and returns those that carry
+    at least one ``_provenance_*`` key with ``_provenance_reviewed`` either
+    ``False`` or absent.
+
+    :param model: The :class:`~etcion.metamodel.model.Model` to query.
+    :returns: A list of matching :class:`~etcion.metamodel.concepts.Concept`
+        instances.  Use :func:`unreviewed_elements` for the Element-only
+        variant when callers expect ``list[Element]``.
+    """
+    return [
+        c
+        for c in model._concepts.values()
+        if _has_provenance(c) and not c.extended_attributes.get("_provenance_reviewed", False)
+    ]
+
+
+def concepts_by_source(model: Model, source: str) -> list[Concept]:
+    """Return concepts whose provenance source matches *source*.
+
+    Walks every :class:`~etcion.metamodel.concepts.Concept` in *model*.
+    Concepts without provenance metadata are silently skipped.
+
+    :param model: The :class:`~etcion.metamodel.model.Model` to query.
+    :param source: The exact source string to match against
+        ``_provenance_source``.
+    :returns: A list of matching :class:`~etcion.metamodel.concepts.Concept`
+        instances.
+    """
+    return [
+        c
+        for c in model._concepts.values()
+        if _has_provenance(c) and c.extended_attributes.get("_provenance_source") == source
+    ]
+
+
+def low_confidence_concepts(model: Model, threshold: float = 0.5) -> list[Concept]:
+    """Return concepts whose provenance confidence score is below *threshold*.
+
+    Walks every :class:`~etcion.metamodel.concepts.Concept` in *model*.
+
+    :param model: The :class:`~etcion.metamodel.model.Model` to query.
+    :param threshold: Confidence cutoff (exclusive upper bound).  Defaults to ``0.5``.
+    :returns: A list of matching :class:`~etcion.metamodel.concepts.Concept` instances.
+    """
+    return [
+        c
+        for c in model._concepts.values()
+        if _has_provenance(c)
+        and isinstance(c.extended_attributes.get("_provenance_confidence"), (int, float))
+        and c.extended_attributes["_provenance_confidence"] < threshold
     ]

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -52,6 +52,20 @@ _XSD_TO_PY_TYPE: dict[str, type] = {
 # Allowed Python type name strings for constraint deserialization.
 _ALLOWED_TYPES: dict[str, type] = {"str": str, "int": int, "float": float, "bool": bool}
 
+
+def _coerce_attr_value(text: str, py_type: type) -> Any:  # noqa: ANN401
+    """Coerce a serialized attribute value back to *py_type*.
+
+    Handles the bool special case where ``bool("False") is True``.  All other
+    types use the type constructor directly.  The return type is intentionally
+    ``Any`` because *py_type* is itself dynamic (str/int/float/bool from the
+    propdef map).
+    """
+    if py_type is bool:
+        return text.strip().lower() in {"true", "1", "yes"}
+    return py_type(text)
+
+
 # Well-known propertyDefinition identifier for the specialization field.
 _SPECIALIZATION_PROPDEF_ID = "propdef-specialization"
 
@@ -107,7 +121,14 @@ def serialize_element(elem: Element) -> etree._Element:
 
 
 def serialize_relationship(rel: Relationship) -> etree._Element:
-    """Serialize a single Relationship to an lxml element node."""
+    """Serialize a single Relationship to an lxml element node.
+
+    Per ADR-050, ``extended_attributes`` declared on a Relationship are
+    emitted as a ``<properties>`` block mirroring the Element path.  The
+    propdef-id scheme namespaces by the relationship's xml_tag so collisions
+    with element propdefs are not possible (relationship and element xml_tag
+    spaces are disjoint).
+    """
     desc = TYPE_REGISTRY[type(rel)]
     el = etree.Element(f"{{{ARCHIMATE_NS}}}relationship", nsmap=NSMAP)
     el.set("identifier", _to_exchange_id(rel.id))
@@ -119,6 +140,16 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
         name_el = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}name")
         name_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
         name_el.text = rel.name
+
+    if rel.extended_attributes:
+        props_container = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}properties")
+        type_name = desc.xml_tag
+        for attr_name, value in rel.extended_attributes.items():
+            prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
+            prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+            val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
+            val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
+            val_el.text = str(value)
 
     for attr_name, extractor in desc.extra_attrs.items():
         val = extractor(rel)
@@ -229,12 +260,16 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
             for attr_name in attrs:
                 declared_ids.add(f"propdef-{type_name}-{attr_name}")
 
-    # Discover undeclared extended attributes on elements.
+    # Discover undeclared extended attributes on elements and relationships.
+    # Per ADR-050 the propdef discovery walk includes relationships so that the
+    # <propertyDefinitions> block is complete for any concept that carries a
+    # property bag; the element/relationship xml_tag spaces are disjoint, so
+    # propdef ids cannot collide.
     undeclared: dict[str, str] = {}  # propdef_id -> attr_name
-    for elem in model.elements:
-        if elem.extended_attributes:
-            type_name = TYPE_REGISTRY[type(elem)].xml_tag
-            for attr_name in elem.extended_attributes:
+    for concept in (*model.elements, *model.relationships):
+        if concept.extended_attributes:
+            type_name = TYPE_REGISTRY[type(concept)].xml_tag
+            for attr_name in concept.extended_attributes:
                 pid = f"propdef-{type_name}-{attr_name}"
                 if pid not in declared_ids:
                     undeclared[pid] = attr_name
@@ -400,7 +435,7 @@ def _deserialize_element(
                 specialization = val_node.text
             elif propdef_map and ref in propdef_map:
                 attr_name, attr_type = propdef_map[ref]
-                extended_attributes[attr_name] = attr_type(val_node.text)
+                extended_attributes[attr_name] = _coerce_attr_value(val_node.text, attr_type)
 
     kwargs: dict[str, Any] = {}
     if specialization:
@@ -413,12 +448,18 @@ def _deserialize_element(
 def _deserialize_relationship(
     node: etree._Element,
     id_map: dict[str, Concept],
+    propdef_map: dict[str, tuple[str, type]] | None = None,
 ) -> Relationship | None:
     """Deserialize a single ``<relationship>`` node.
 
     Source and target are resolved from ``id_map`` (keyed by exchange-format
     IDs, e.g. ``id-<uuid>``).  Returns ``None`` and emits a warning when the
     type is unknown or a reference cannot be resolved.
+
+    Per ADR-050, ``<properties>`` children declared on a relationship are
+    re-hydrated into ``extended_attributes`` via ``propdef_map`` (the same
+    mapping used by :func:`_deserialize_element`).  Pass ``None`` for models
+    without profile-declared relationship properties.
     """
     type_attr = node.get(f"{{{XSI_NS}}}type")
     if type_attr not in _TAG_TO_TYPE:
@@ -435,8 +476,23 @@ def _deserialize_relationship(
         return None
     name_node = node.find(f"{{{ARCHIMATE_NS}}}name")
     name: str = name_node.text or "" if name_node is not None else ""
+
+    extended_attributes: dict[str, Any] = {}
+    props_node = node.find(f"{{{ARCHIMATE_NS}}}properties")
+    if props_node is not None and propdef_map:
+        for prop_node in props_node:
+            ref = prop_node.get("propertyDefinitionRef", "")
+            val_node = prop_node.find(f"{{{ARCHIMATE_NS}}}value")
+            if val_node is None or not val_node.text:
+                continue
+            if ref in propdef_map:
+                attr_name, attr_type = propdef_map[ref]
+                extended_attributes[attr_name] = _coerce_attr_value(val_node.text, attr_type)
+
     # Extra attrs (access_mode, sign, etc.) are deferred; Serving has none.
     kwargs: dict[str, Any] = {}
+    if extended_attributes:
+        kwargs["extended_attributes"] = extended_attributes
     return cls(id=internal_id, name=name, source=source, target=target, **kwargs)  # type: ignore[call-arg, return-value]
 
 
@@ -457,9 +513,12 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
     root = tree.getroot()
     model = Model()
 
-    # Phase 1: parse propertyDefinitions
+    # Phase 1: parse propertyDefinitions.
+    # Per ADR-050 the synthetic "Imported" profile may target any Concept
+    # subclass (Element, Relationship, or RelationshipConnector), so the
+    # attr_extensions registry is keyed on Concept rather than Element only.
     propdef_map: dict[str, tuple[str, type]] = {}
-    attr_extensions: dict[type[Element], dict[str, type]] = {}
+    attr_extensions: dict[type[Concept], dict[str, type]] = {}
     propdefs_node = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
     if propdefs_node is not None:
         for pd_node in propdefs_node:
@@ -472,31 +531,26 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
             # Identifier scheme: "propdef-TypeName-attr_name"
             parts = pd_id.split("-", 2)
             if len(parts) == 3 and parts[1] in _TAG_TO_TYPE:
-                raw_cls = _TAG_TO_TYPE[parts[1]]
-                if not (isinstance(raw_cls, type) and issubclass(raw_cls, Element)):
-                    continue
-                elem_cls: type[Element] = raw_cls
-                if elem_cls not in attr_extensions:
-                    attr_extensions[elem_cls] = {}
-                attr_extensions[elem_cls][attr_name] = py_type
+                concept_cls: type[Concept] = _TAG_TO_TYPE[parts[1]]
+                if concept_cls not in attr_extensions:
+                    attr_extensions[concept_cls] = {}
+                attr_extensions[concept_cls][attr_name] = py_type
 
     # Phase 1b: parse <etcion:profileConstraints> if present (Issue #52).
     # This element carries the full constraint metadata for profiles that use
     # the dict constraint form and was written by serialize_model.
     # Constraint metadata is indexed by (xml_tag, attr_name) to allow overlay
     # onto the attr_extensions built from <propertyDefinitions>.
-    imported_constraints: dict[type[Element], dict[str, Any]] = {}
+    imported_constraints: dict[type[Concept], dict[str, Any]] = {}
     pc_node = root.find(f"{{{_ETCION_NS}}}profileConstraints")
     if pc_node is not None:
         for prof_el in pc_node:
             for et_el in prof_el:
                 xml_tag = et_el.get("tag", "")
                 elem_cls_raw = _TAG_TO_TYPE.get(xml_tag)
-                if elem_cls_raw is None or not (
-                    isinstance(elem_cls_raw, type) and issubclass(elem_cls_raw, Element)
-                ):
+                if elem_cls_raw is None:
                     continue
-                elem_cls_ct: type[Element] = elem_cls_raw
+                concept_cls_ct: type[Concept] = elem_cls_raw
                 for a_el in et_el:
                     a_name = a_el.get("name", "")
                     raw_text = a_el.text or "{}"
@@ -506,9 +560,9 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
                         constraint_dict["type"] = _ALLOWED_TYPES.get(
                             constraint_dict.get("type", "str"), str
                         )
-                        if elem_cls_ct not in imported_constraints:
-                            imported_constraints[elem_cls_ct] = {}
-                        imported_constraints[elem_cls_ct][a_name] = constraint_dict
+                        if concept_cls_ct not in imported_constraints:
+                            imported_constraints[concept_cls_ct] = {}
+                        imported_constraints[concept_cls_ct][a_name] = constraint_dict
                     except (json.JSONDecodeError, KeyError):
                         pass  # gracefully skip malformed constraint entries
 
@@ -550,11 +604,13 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
     for elem in parsed_elements:
         model.add(elem)
 
-    # Phase 5: relationships
+    # Phase 5: relationships.  Per ADR-050 the propdef_map is also threaded
+    # into the relationship deserializer so that <properties> on a
+    # <relationship> rehydrate into rel.extended_attributes.
     rels_node = root.find(f"{{{ARCHIMATE_NS}}}relationships")
     if rels_node is not None:
         for rel_node in rels_node:
-            rel = _deserialize_relationship(rel_node, id_map)
+            rel = _deserialize_relationship(rel_node, id_map, propdef_map if propdef_map else None)
             if rel is not None:
                 model.add(rel)
                 # Keep id_map up to date so views can reference relationships.

--- a/test/metamodel/test_concepts.py
+++ b/test/metamodel/test_concepts.py
@@ -68,6 +68,15 @@ class TestConcept:
         """Concept.model_config['arbitrary_types_allowed'] is True."""
         assert Concept.model_config.get("arbitrary_types_allowed") is True
 
+    def test_extended_attributes_on_concept_root(self) -> None:
+        """ADR-050: extended_attributes lives on Concept, not Element only."""
+        assert "extended_attributes" in Concept.model_fields
+
+    def test_extended_attributes_default_is_empty_dict(self) -> None:
+        """ADR-050: every Concept subclass has extended_attributes defaulting to {}."""
+        c = ConcreteConcept()
+        assert c.extended_attributes == {}
+
 
 class ConcreteElement_1(Element):
     @property
@@ -261,6 +270,18 @@ class TestRelationship:
         concept_pos = mro.index(Concept)
         assert mixin_pos < concept_pos
 
+    def test_extended_attributes_inherited_from_concept(self) -> None:
+        """ADR-050: a Relationship subclass exposes extended_attributes."""
+        src = ConcreteElement_2(name="src")
+        tgt = ConcreteElement_2(name="tgt")
+        rel = ConcreteRelationship(
+            name="R",
+            source=src,
+            target=tgt,
+            extended_attributes={"priority": "high"},
+        )
+        assert rel.extended_attributes == {"priority": "high"}
+
 
 class ConcreteConnector(RelationshipConnector):
     @property
@@ -315,3 +336,8 @@ class TestRelationshipConnector:
     def test_no_attribute_mixin_in_mro(self) -> None:
         """AttributeMixin is not in RelationshipConnector.__mro__."""
         assert AttributeMixin not in RelationshipConnector.__mro__
+
+    def test_extended_attributes_inherited_from_concept(self) -> None:
+        """ADR-050: a RelationshipConnector subclass exposes extended_attributes."""
+        c = ConcreteConnector(extended_attributes={"role": "junction"})
+        assert c.extended_attributes == {"role": "junction"}

--- a/test/metamodel/test_profile_constraints.py
+++ b/test/metamodel/test_profile_constraints.py
@@ -687,3 +687,74 @@ class TestXmlConstraintRoundTrip:
 
         errors = restored.validate()
         assert errors == []
+
+
+# ===========================================================================
+# ADR-050 / Issue #100 — extended_attributes on relationships and connectors
+# ===========================================================================
+
+
+class TestRelationshipExtendedAttributeValidation:
+    """ADR-050: Model.validate() walks relationships for extended-attribute checks.
+
+    Specialization remains Element-only; only the extended_attributes path
+    broadens to Concept.
+    """
+
+    def _build(self, attr_value: object) -> Model:
+        from etcion.metamodel.application import ApplicationComponent, ApplicationService
+        from etcion.metamodel.relationships import Serving
+
+        m = Model()
+        a = ApplicationComponent(name="src")
+        b = ApplicationService(name="tgt")
+        rel = Serving(source=a, target=b, extended_attributes={"priority": attr_value})
+        m.add(a)
+        m.add(b)
+        m.add(rel)
+        m.apply_profile(
+            Profile(
+                name="RelOps",
+                attribute_extensions={Serving: {"priority": str}},
+            )
+        )
+        return m
+
+    def test_valid_relationship_extension_passes(self) -> None:
+        """No extension-related errors when the relationship value matches the constraint.
+
+        The model may surface unrelated permission-matrix warnings for the
+        Serving combination; we filter to extension errors only.
+        """
+        errors = self._build("high").validate()
+        ext_errors = [e for e in errors if "extended attribute" in str(e)]
+        assert ext_errors == []
+
+    def test_undeclared_relationship_extension_flagged(self) -> None:
+        from etcion.metamodel.application import ApplicationComponent, ApplicationService
+        from etcion.metamodel.relationships import Serving
+
+        m = Model()
+        a = ApplicationComponent(name="src")
+        b = ApplicationService(name="tgt")
+        rel = Serving(source=a, target=b, extended_attributes={"unknown_key": "x"})
+        m.add(a)
+        m.add(b)
+        m.add(rel)
+        m.apply_profile(Profile(name="Rel", attribute_extensions={Serving: {"priority": str}}))
+        errors = m.validate()
+        assert any("Relationship" in str(e) and "unknown_key" in str(e) for e in errors)
+
+    def test_type_mismatch_on_relationship_extension(self) -> None:
+        errors = self._build(123).validate()
+        assert any(
+            "Relationship" in str(e) and "priority" in str(e) and "expected type str" in str(e)
+            for e in errors
+        )
+
+    def test_specialization_remains_element_only(self) -> None:
+        """ADR-050 explicitly keeps `specializations` keyed on Element."""
+        from etcion.metamodel.relationships import Serving
+
+        with pytest.raises(PydanticValidationError, match="not a subclass of Element"):
+            Profile(name="bad", specializations={Serving: ["fast"]})  # type: ignore[dict-item]

--- a/test/metamodel/test_profiles.py
+++ b/test/metamodel/test_profiles.py
@@ -191,16 +191,38 @@ class TestSpecializationKeyValidation:
 
 
 class TestAttributeExtensionKeyValidation:
-    """STORY-18.2.1: attribute_extensions keys must be Element subclasses."""
+    """STORY-18.2.1 / ADR-050: attribute_extensions keys must be Concept subclasses.
 
-    def test_non_element_key_rejected(self) -> None:
+    Per ADR-050, ``attribute_extensions`` keys broadened from ``Element`` to
+    ``Concept``: profiles may declare extended attributes for elements,
+    relationships, and connectors alike.  ``specializations`` keys remain
+    Element-only.
+    """
+
+    def test_non_concept_key_rejected(self) -> None:
         with pytest.raises(
-            PydanticValidationError, match="attribute_extensions.*not a subclass of Element"
+            PydanticValidationError, match="attribute_extensions.*not a subclass of Concept"
         ):
             Profile(
                 name="Bad",
                 attribute_extensions={int: {"x": str}},  # type: ignore[dict-item]
             )
+
+    def test_relationship_key_accepted(self) -> None:
+        """ADR-050: a Relationship subclass is now a valid attribute_extensions key."""
+        from etcion.metamodel.relationships import Serving
+
+        p = Profile(name="Ok", attribute_extensions={Serving: {"priority": int}})
+        assert Serving in p.attribute_extensions
+        assert "priority" in p.get_constraints(Serving)
+
+    def test_connector_key_accepted(self) -> None:
+        """ADR-050: a RelationshipConnector subclass is now a valid attribute_extensions key."""
+        from etcion.metamodel.relationships import Junction
+
+        p = Profile(name="Ok", attribute_extensions={Junction: {"role": str}})
+        assert Junction in p.attribute_extensions
+        assert "role" in p.get_constraints(Junction)
 
 
 # ===========================================================================

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -806,6 +806,71 @@ class TestProfileXmlRoundTrip:
         assert len(restored.elements) == len(simple_model.elements)
 
 
+class TestRelationshipExtendedAttributesRoundTrip:
+    """ADR-050 / Issue #100 — extended_attributes on relationships round-trip cleanly."""
+
+    def _build(self) -> Model:
+        m = Model()
+        comp = ApplicationComponent(name="Order API")
+        svc = BusinessService(name="Order Fulfilment")
+        rel = Serving(
+            name="",
+            source=comp,
+            target=svc,
+            extended_attributes={
+                "_provenance_source": "etl-v2",
+                "_provenance_confidence": 0.87,
+                "_provenance_reviewed": False,
+            },
+        )
+        m.add(comp)
+        m.add(svc)
+        m.add(rel)
+        m.apply_profile(
+            Profile(
+                name="RelOps",
+                attribute_extensions={
+                    Serving: {
+                        "_provenance_source": str,
+                        "_provenance_confidence": float,
+                        "_provenance_reviewed": bool,
+                    },
+                },
+            )
+        )
+        return m
+
+    def test_round_trip_relationship_extended_attributes(self) -> None:
+        """Extended attributes on a Relationship survive serialize/deserialize."""
+        original = self._build()
+        tree = serialize_model(original)
+        restored = deserialize_model(tree)
+
+        rel = restored.relationships[0]
+        assert rel.extended_attributes == {
+            "_provenance_source": "etl-v2",
+            "_provenance_confidence": 0.87,
+            "_provenance_reviewed": False,
+        }
+
+    def test_serialized_xml_is_xsd_valid(self) -> None:
+        """<properties> on <relationship> must be XSD-valid against the bundled schema."""
+        tree = serialize_model(self._build(), model_name="ADR050 Round-trip")
+        errors = validate_exchange_format(tree)
+        assert errors == [], f"XSD validation errors: {errors}"
+
+    def test_relationship_propdefs_emitted(self) -> None:
+        """propdef-discovery walk includes Relationship subclasses (ADR-050)."""
+        tree = serialize_model(self._build())
+        root = tree.getroot()
+        propdefs = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert propdefs is not None
+        ids = [pd.get("identifier") for pd in propdefs]
+        assert "propdef-Serving-_provenance_source" in ids
+        assert "propdef-Serving-_provenance_confidence" in ids
+        assert "propdef-Serving-_provenance_reviewed" in ids
+
+
 class TestProfileXmlRoundTripIntegrity:
     """Issue #50 — comprehensive round-trip integrity for XML profile serialization."""
 

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -367,3 +367,134 @@ class TestLowConfidenceElements:
 
         assert hasattr(etcion, "low_confidence_elements")
         assert etcion.low_confidence_elements is low_confidence_elements
+
+
+# ===========================================================================
+# ADR-050 / Issue #100 — concept-wide provenance helpers
+# ===========================================================================
+
+
+class TestUnreviewedConcepts:
+    """unreviewed_concepts walks elements, relationships, and connectors."""
+
+    def _build(self) -> Model:
+        from etcion import unreviewed_concepts  # noqa: F401  (import-time check)
+        from etcion.metamodel.application import ApplicationComponent, ApplicationService
+        from etcion.metamodel.relationships import Serving
+
+        m = Model()
+        m.apply_profile(INGESTION_PROFILE)
+        m.apply_profile(
+            Profile(
+                name="RelProvenance",
+                attribute_extensions={
+                    Serving: {
+                        "_provenance_source": str,
+                        "_provenance_reviewed": bool,
+                    },
+                },
+            )
+        )
+        elem = ApplicationComponent(
+            name="reviewed-elem",
+            extended_attributes={"_provenance_source": "etl", "_provenance_reviewed": True},
+        )
+        unreviewed_elem = ApplicationService(
+            name="unreviewed-elem",
+            extended_attributes={"_provenance_source": "etl", "_provenance_reviewed": False},
+        )
+        unreviewed_rel = Serving(
+            name="",
+            source=elem,
+            target=unreviewed_elem,
+            extended_attributes={"_provenance_source": "rg", "_provenance_reviewed": False},
+        )
+        m.add(elem)
+        m.add(unreviewed_elem)
+        m.add(unreviewed_rel)
+        return m
+
+    def test_returns_unreviewed_relationship(self) -> None:
+        from etcion import unreviewed_concepts
+
+        result = unreviewed_concepts(self._build())
+        names_or_types = {getattr(c, "name", None) or type(c).__name__ for c in result}
+        assert "unreviewed-elem" in names_or_types
+        assert "Serving" in names_or_types  # the relationship was synthesized
+
+    def test_excludes_reviewed_concepts(self) -> None:
+        from etcion import unreviewed_concepts
+
+        result = unreviewed_concepts(self._build())
+        names = {getattr(c, "name", None) for c in result}
+        assert "reviewed-elem" not in names
+
+    def test_element_only_helper_unchanged(self) -> None:
+        """unreviewed_elements still returns list[Element] only (no relationships)."""
+        from etcion.provenance import unreviewed_elements
+
+        m = self._build()
+        result = unreviewed_elements(m)
+        from etcion.metamodel.concepts import Element
+
+        assert all(isinstance(c, Element) for c in result)
+
+    def test_exported_from_package(self) -> None:
+        from etcion import (
+            concepts_by_source,
+            low_confidence_concepts,
+            unreviewed_concepts,
+        )
+
+        assert callable(unreviewed_concepts)
+        assert callable(concepts_by_source)
+        assert callable(low_confidence_concepts)
+
+
+class TestConceptsBySource:
+    def test_includes_relationships(self) -> None:
+        from etcion import concepts_by_source
+        from etcion.metamodel.application import ApplicationComponent, ApplicationService
+        from etcion.metamodel.relationships import Serving
+
+        m = Model()
+        m.apply_profile(INGESTION_PROFILE)
+        m.apply_profile(
+            Profile(
+                name="RelProv",
+                attribute_extensions={Serving: {"_provenance_source": str}},
+            )
+        )
+        a = ApplicationComponent(name="a", extended_attributes={"_provenance_source": "rg"})
+        b = ApplicationService(name="b")
+        rel = Serving(source=a, target=b, extended_attributes={"_provenance_source": "rg"})
+        m.add(a)
+        m.add(b)
+        m.add(rel)
+        result = concepts_by_source(m, "rg")
+        # The element and the relationship both match.
+        assert len(result) == 2
+
+
+class TestLowConfidenceConcepts:
+    def test_includes_low_confidence_relationship(self) -> None:
+        from etcion import low_confidence_concepts
+        from etcion.metamodel.application import ApplicationComponent, ApplicationService
+        from etcion.metamodel.relationships import Serving
+
+        m = Model()
+        m.apply_profile(
+            Profile(
+                name="Conf",
+                attribute_extensions={Serving: {"_provenance_confidence": float}},
+            )
+        )
+        a = ApplicationComponent(name="a")
+        b = ApplicationService(name="b")
+        rel = Serving(source=a, target=b, extended_attributes={"_provenance_confidence": 0.3})
+        m.add(a)
+        m.add(b)
+        m.add(rel)
+        result = low_confidence_concepts(m, threshold=0.5)
+        assert len(result) == 1
+        assert isinstance(result[0], Serving)


### PR DESCRIPTION
## Summary

Implements [ADR-050](docs/adr/ADR-050-extended-attributes-on-concept.md). Lifts `extended_attributes` from `Element` onto `Concept` so relationships and connectors (Junction) can carry profile-declared extended attributes -- including provenance keys -- the same way elements do. Closes #100.

### Key changes

- **`Concept.extended_attributes`** -- field moved from Element to the abstract root, mirroring `id`'s placement. Existing Element callers continue to work unchanged.
- **Profile contract relaxed** -- `attribute_extensions` keys broadened from `Element` to `Concept`. `specializations` keys remain `Element`-only (specialization is an Element-layer feature). `get_constraints()` parameter renamed `elem_type` -> `concept_type`.
- **`Model.validate()` walks all concepts** -- relationship-level and connector-level extended-attribute violations now surface with typed error labels (`Relationship 'id': ...`).
- **Relationship XML round-trip** -- `serialize_relationship` emits `<properties>`; the propdef-discovery walk in `serialize_model` includes relationships; the deserializer rehydrates `rel.extended_attributes` from `<properties>`. Junction `<properties>` parity is a known follow-up gap (in-memory and JSON paths work today).
- **bool round-trip latent bug fixed** -- `bool("False")` is `True` in Python. New `_coerce_attr_value` helper handles bool via case-insensitive string comparison; used by both element and relationship deserializers.
- **Provenance helpers split** -- `unreviewed_elements` / `elements_by_source` / `low_confidence_elements` keep their `list[Element]` return contract; new `unreviewed_concepts` / `concepts_by_source` / `low_confidence_concepts` walk every concept. `INGESTION_PROFILE` stays element-keyed; module docstring documents the relationship-targeted pattern.
- **CHANGELOG** under "Unreleased" / "Behavior changes" with a forward-compat note: relationship `<properties>` written by etcion >= 0.12 cannot be deserialized by older versions.

## Test plan

- [x] `pytest`: 3249 passed, 2 skipped (skips pre-existing, unrelated)
- [x] `mypy src/`: clean
- [x] `ruff format --check src/ test/`: clean
- [x] `ruff check src/ test/`: clean
- [x] New regression tests cover: extended_attributes presence on Concept/Relationship/connector, Profile accepting Relationship and Connector keys, Model.validate() flagging undeclared/wrong-type relationship extensions, XML round-trip preserving relationship properties and producing XSD-valid output, concept-wide provenance helpers picking up synthesized relationships
- [ ] CI green on this PR