### PR TITLE
Promote ConceptChange/FieldChange.to_dict() to public (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `concepts_by_source`, `low_confidence_concepts`. The element-scoped
   helpers (`unreviewed_elements`, etc.) preserve their `list[Element]`
   return contract unchanged.
+- `FieldChange.to_dict()` and `ConceptChange.to_dict()` (closes #105).
+  The per-row JSON-serializable helper that was previously inlined inside
+  `ModelDiff.to_dict()` is now public on each dataclass, so consumers
+  persisting individual diff rows (e.g. `MergeResult.conflicts` entries
+  into an audit table) no longer need to reimplement it.
+  `ModelDiff.to_dict()`'s output shape is byte-identical -- the
+  `_schema_version` stays at `"1.0"`.
 
 ### Fixed
 

--- a/src/etcion/comparison.py
+++ b/src/etcion/comparison.py
@@ -24,6 +24,17 @@ class FieldChange:
     old: Any
     new: Any
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the value pair.
+
+        The returned shape is ``{"old": ..., "new": ...}`` -- intentionally
+        without a ``"field"`` key because :class:`FieldChange` instances are
+        the values of a field-keyed mapping in :attr:`ConceptChange.changes`,
+        and embedding the field name inside the value would duplicate it.
+        Callers reconstructing a flat row can use the outer dict key.
+        """
+        return {"old": self.old, "new": self.new}
+
 
 @dataclass(frozen=True)
 class ConceptChange:
@@ -32,6 +43,19 @@ class ConceptChange:
     concept_id: str
     concept_type: str
     changes: dict[str, FieldChange]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of this change record.
+
+        Useful when persisting per-conflict rows (e.g. each
+        :attr:`~etcion.merge.MergeResult.conflicts` entry into an audit
+        table) without going through :meth:`ModelDiff.to_dict`.
+        """
+        return {
+            "concept_id": self.concept_id,
+            "concept_type": self.concept_type,
+            "changes": {k: fc.to_dict() for k, fc in self.changes.items()},
+        }
 
 
 @dataclass(frozen=True)
@@ -52,18 +76,11 @@ class ModelDiff:
                 "name": getattr(c, "name", None),
             }
 
-        def _change_entry(cc: ConceptChange) -> dict[str, Any]:
-            return {
-                "concept_id": cc.concept_id,
-                "concept_type": cc.concept_type,
-                "changes": {k: {"old": fc.old, "new": fc.new} for k, fc in cc.changes.items()},
-            }
-
         return {
             "_schema_version": "1.0",
             "added": [_concept_entry(c) for c in self.added],
             "removed": [_concept_entry(c) for c in self.removed],
-            "modified": [_change_entry(cc) for cc in self.modified],
+            "modified": [cc.to_dict() for cc in self.modified],
         }
 
     def summary(self) -> str:

--- a/test/test_comparison.py
+++ b/test/test_comparison.py
@@ -251,6 +251,126 @@ class TestToDict:
         assert d["_schema_version"] == "1.0"
 
 
+class TestFieldChangeToDict:
+    """Issue #105: FieldChange.to_dict() returns {"old", "new"}."""
+
+    def test_basic_shape(self) -> None:
+        fc = FieldChange(field="name", old="Alice", new="Alicia")
+        assert fc.to_dict() == {"old": "Alice", "new": "Alicia"}
+
+    def test_does_not_include_field_key(self) -> None:
+        """The field name is the outer dict key on the parent ConceptChange.
+
+        Embedding it inside the value would duplicate the data; this test
+        pins that contract.
+        """
+        fc = FieldChange(field="name", old="A", new="B")
+        assert "field" not in fc.to_dict()
+
+    def test_none_values_preserved(self) -> None:
+        fc = FieldChange(field="description", old=None, new="some text")
+        assert fc.to_dict() == {"old": None, "new": "some text"}
+
+    def test_nested_dict_value_passthrough(self) -> None:
+        """to_dict must not sanitize values; that is json.dumps's job."""
+        fc = FieldChange(field="extended_attributes", old={"a": 1}, new={"a": 2, "b": 3})
+        assert fc.to_dict() == {"old": {"a": 1}, "new": {"a": 2, "b": 3}}
+
+
+class TestConceptChangeToDict:
+    """Issue #105: ConceptChange.to_dict() exposes the per-row serialization helper."""
+
+    def test_full_shape(self) -> None:
+        cc = ConceptChange(
+            concept_id="a1",
+            concept_type="BusinessActor",
+            changes={
+                "name": FieldChange(field="name", old="Alice", new="Alicia"),
+                "description": FieldChange(field="description", old=None, new="primary user"),
+            },
+        )
+        assert cc.to_dict() == {
+            "concept_id": "a1",
+            "concept_type": "BusinessActor",
+            "changes": {
+                "name": {"old": "Alice", "new": "Alicia"},
+                "description": {"old": None, "new": "primary user"},
+            },
+        }
+
+    def test_empty_changes_dict(self) -> None:
+        """Edge case: a ConceptChange with no field-level changes still serializes cleanly."""
+        cc = ConceptChange(concept_id="a1", concept_type="BusinessActor", changes={})
+        assert cc.to_dict() == {
+            "concept_id": "a1",
+            "concept_type": "BusinessActor",
+            "changes": {},
+        }
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        cc = ConceptChange(
+            concept_id="a1",
+            concept_type="BusinessActor",
+            changes={"name": FieldChange(field="name", old="A", new="B")},
+        )
+        # Must not raise.
+        result = json.dumps(cc.to_dict())
+        assert isinstance(result, str)
+
+
+class TestModelDiffToDictUnchangedShape:
+    """Issue #105: ModelDiff.to_dict() output must be byte-identical after the refactor.
+
+    This is the contract anchor: ModelDiff.to_dict() now delegates to
+    ConceptChange.to_dict() (which delegates to FieldChange.to_dict()), but
+    the wire shape is unchanged. _schema_version stays at "1.0".
+    """
+
+    def test_modeldiff_shape_unchanged_for_modified_entries(self) -> None:
+        """The fixed dict literal pins the wire shape across the refactor."""
+        cc = ConceptChange(
+            concept_id="a1",
+            concept_type="BusinessActor",
+            changes={"name": FieldChange(field="name", old="Alice", new="Alicia")},
+        )
+        diff = ModelDiff(added=(), removed=(), modified=(cc,))
+        assert diff.to_dict() == {
+            "_schema_version": "1.0",
+            "added": [],
+            "removed": [],
+            "modified": [
+                {
+                    "concept_id": "a1",
+                    "concept_type": "BusinessActor",
+                    "changes": {"name": {"old": "Alice", "new": "Alicia"}},
+                }
+            ],
+        }
+
+    def test_full_diff_shape_unchanged(self) -> None:
+        """Comprehensive shape pin: added + removed + modified all in one dict."""
+        added = BusinessActor(id="new1", name="New")
+        removed = BusinessActor(id="gone1", name="Gone")
+        cc = ConceptChange(
+            concept_id="mod1",
+            concept_type="BusinessActor",
+            changes={"name": FieldChange(field="name", old="Old", new="New name")},
+        )
+        diff = ModelDiff(added=(added,), removed=(removed,), modified=(cc,))
+        assert diff.to_dict() == {
+            "_schema_version": "1.0",
+            "added": [{"id": "new1", "type": "BusinessActor", "name": "New"}],
+            "removed": [{"id": "gone1", "type": "BusinessActor", "name": "Gone"}],
+            "modified": [
+                {
+                    "concept_id": "mod1",
+                    "concept_type": "BusinessActor",
+                    "changes": {"name": {"old": "Old", "new": "New name"}},
+                }
+            ],
+        }
+
+
 # ---------------------------------------------------------------------------
 # summary()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the architect's recommendation on #105: add public `to_dict()` to both `FieldChange` and `ConceptChange`, refactor `ModelDiff.to_dict()` to delegate. Closes #105.

The per-row serialization helper (`_change_entry`) was previously inlined inside `ModelDiff.to_dict`. Consumers wanting to persist a single diff row (e.g. each `MergeResult.conflicts` entry into an audit table) had no public hook.

### Why both, not just `ConceptChange`?

The architect flagged that the deeper issue is symmetry across all three public dataclasses in `comparison.py`. Fixing only `ConceptChange` would re-encode the same wart one level down: callers wanting to persist a `FieldChange` directly would still have to inline `{"old": ..., "new": ...}`. Adding both is cheap and produces a clean call chain: `ModelDiff.to_dict()` -> `ConceptChange.to_dict()` -> `FieldChange.to_dict()`.

### Wire shape unchanged

`ModelDiff.to_dict()` output is byte-identical -- `_schema_version` stays at `"1.0"`. This is the contract anchor and is pinned by `TestModelDiffToDictUnchangedShape::test_full_diff_shape_unchanged` against a fixed dict literal.

### Out of scope (separate follow-up)

`MergeResult.to_dict()` -- the result dataclass exposes `summary()`, `__str__`, `__bool__`, `_repr_html_` (Jupyter) but no JSON path. The architect flagged this as the *real* serialization gap in the merge/diff family. Will be filed as its own issue.

## Test plan

- [x] `pytest test/test_comparison.py`: 42 passed (12 new + 30 existing, all green -- existing tests still passing proves the wire shape didn't change)
- [x] Full suite: 3258 passed, 2 skipped (skips pre-existing, unrelated)
- [x] `mypy src/`: clean
- [x] `ruff check src/ test/`: clean
- [x] `ruff format --check src/ test/`: clean
- [ ] CI green on this PR