### PR TITLE
Fix XML serialization of abstract-keyed profile attribute_extensions (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - XML round-trip of `bool` extended attributes was previously broken
   because `bool("False")` is `True`. The deserializer now coerces
   bool values via case-insensitive string comparison.
+- `write_model` / `serialize_model` no longer raise `KeyError` when a
+  profile declares `attribute_extensions` against an abstract base
+  (`Element`, `Relationship`, or `Concept`). Abstract keys are now fanned
+  out to one property definition per concrete concept type present in the
+  model, matching `Profile.get_constraints`' subclass-aware semantics on
+  the validation side. The reconstructed profile after a round-trip is
+  keyed on those concrete types rather than the original abstract base.
+  Closes #110.
 
 ## [0.11.1] - 27 Apr 2026
 

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -81,6 +81,30 @@ def _to_exchange_id(internal_id: str) -> str:
     return internal_id if internal_id.startswith("id-") else f"id-{internal_id}"
 
 
+def _expanded_attribute_extensions(
+    profile: Profile, present_types: set[type[Concept]]
+) -> dict[type[Concept], dict[str, Any]]:
+    """Fan abstract profile keys out to concrete concept types in the model.
+
+    Profile.get_constraints honors abstract bases via issubclass matching, but
+    the XML Exchange Format keys property definitions by concrete type tag.
+    Abstract keys (e.g. ``Element``, ``Relationship``, ``Concept``) are absent
+    from TYPE_REGISTRY, so this helper expands each abstract entry to one
+    entry per concrete type of the right shape present in the model.  Concrete
+    keys pass through unchanged.  On (type, attr) collisions the later-declared
+    entry wins — matching Profile.get_constraints' merge order.
+    """
+    expanded: dict[type[Concept], dict[str, Any]] = {}
+    for cls, attrs in profile.attribute_extensions.items():
+        if cls in TYPE_REGISTRY:
+            targets: list[type[Concept]] = [cls]
+        else:
+            targets = [c for c in present_types if issubclass(c, cls)]
+        for tgt in targets:
+            expanded.setdefault(tgt, {}).update(attrs)
+    return expanded
+
+
 def serialize_element(elem: Element) -> etree._Element:
     """Serialize a single Element to an lxml element node."""
     desc = TYPE_REGISTRY[type(elem)]
@@ -252,10 +276,18 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
     # no dangling propertyDefinitionRef values remain.
     has_specializations = any(e.specialization for e in model.elements)
 
+    # Concrete concept types actually present in the model — drives expansion
+    # of abstract profile keys (Issue #110).  Includes both elements and
+    # relationships since ADR-050 broadened attribute_extensions keys from
+    # Element to Concept.
+    present_concept_types: set[type[Concept]] = {
+        type(c) for c in (*model.elements, *model.relationships)
+    }
+
     # Build set of profile-declared propdef ids and collect all element refs.
     declared_ids: set[str] = set()
     for profile in model.profiles:
-        for cls, attrs in profile.attribute_extensions.items():
+        for cls, attrs in _expanded_attribute_extensions(profile, present_concept_types).items():
             type_name = TYPE_REGISTRY[cls].xml_tag
             for attr_name in attrs:
                 declared_ids.add(f"propdef-{type_name}-{attr_name}")
@@ -286,7 +318,9 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
             pd_name.text = "specialization"
 
         for profile in model.profiles:
-            for cls, attrs in profile.attribute_extensions.items():
+            for cls, attrs in _expanded_attribute_extensions(
+                profile, present_concept_types
+            ).items():
                 type_name = TYPE_REGISTRY[cls].xml_tag
                 for attr_name, raw_value in attrs.items():
                     # Resolve the Python type whether raw_value is a bare type or dict.
@@ -319,7 +353,7 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
     #       </etcion:elementType>
     #     </etcion:profile>
     #   </etcion:profileConstraints>
-    constraint_profiles = _collect_constraint_profiles(model)
+    constraint_profiles = _collect_constraint_profiles(model, present_concept_types)
     if constraint_profiles:
         pc_root = etree.SubElement(root, f"{{{_ETCION_NS}}}profileConstraints")
         for prof_name, type_attrs in constraint_profiles.items():
@@ -344,7 +378,7 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
 
 
 def _collect_constraint_profiles(
-    model: Model,
+    model: Model, present_concept_types: set[type[Concept]]
 ) -> dict[str, dict[str, dict[str, Any]]]:
     """Collect constraint metadata from profiles that use the dict constraint form.
 
@@ -356,11 +390,15 @@ def _collect_constraint_profiles(
     constraint with the ``type`` key replaced by the type's ``__name__`` string.
 
     Only profiles that have at least one dict-form constraint are included.
+
+    Abstract profile keys (e.g. ``Element``) are fanned out to the concrete
+    element types present in the model (Issue #110); the emitted metadata
+    matches the concrete propdef ids written elsewhere in the serializer.
     """
     result: dict[str, dict[str, dict[str, Any]]] = {}
     for profile in model.profiles:
         type_map: dict[str, dict[str, Any]] = {}
-        for cls, attrs in profile.attribute_extensions.items():
+        for cls, attrs in _expanded_attribute_extensions(profile, present_concept_types).items():
             xml_tag = TYPE_REGISTRY[cls].xml_tag
             attr_map: dict[str, Any] = {}
             for attr_name, raw_value in attrs.items():

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -1127,3 +1127,105 @@ class TestViewXmlRoundTrip:
         """Models without views round-trip without error and produce no views."""
         restored = self._round_trip(simple_model)
         assert len(restored.views) == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #110: Element-keyed attribute_extensions must serialize to XML
+# ---------------------------------------------------------------------------
+
+
+class TestIssue110ElementKeyedProfile:
+    """Issue #110 — write_model fails for Profiles with abstract Element
+    attribute_extensions.
+
+    Validation already honors abstract Element keys via subclass matching
+    (Profile.get_constraints).  The XML writer must do the same: an
+    Element-keyed declaration should fan out to a propdef for every concrete
+    element type present in the model.
+    """
+
+    def _build(self) -> Model:
+        from etcion.metamodel.concepts import Element
+
+        m = Model()
+        comp = ApplicationComponent(
+            name="Order Service",
+            extended_attributes={"_owner": "architecture"},
+        )
+        actor = BusinessActor(
+            name="Customer Rep",
+            extended_attributes={"_owner": "ops"},
+        )
+        m.add(comp)
+        m.add(actor)
+        m.add(Association(name="", source=comp, target=actor))
+        m.apply_profile(
+            Profile(
+                name="PipelineMetadata",
+                attribute_extensions={
+                    Element: {"_owner": {"type": str, "required": True}},
+                },
+            )
+        )
+        return m
+
+    def test_serialize_does_not_raise(self) -> None:
+        """The KeyError reported in #110: serialize_model must not raise."""
+        serialize_model(self._build())
+
+    def test_propdef_emitted_per_concrete_type_present(self) -> None:
+        """One propdef per (concrete element type, attr) actually in the model."""
+        root = serialize_model(self._build()).getroot()
+        pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd_container is not None
+        identifiers = {pd.get("identifier") for pd in pd_container}
+        assert "propdef-ApplicationComponent-_owner" in identifiers
+        assert "propdef-BusinessActor-_owner" in identifiers
+        # No abstract-base propdef leaks through.
+        assert "propdef-Element-_owner" not in identifiers
+
+    def test_round_trip_validate_passes(self) -> None:
+        """Round-tripped model still validates clean (constraints survived)."""
+        original = self._build()
+        assert original.validate() == []
+        restored = deserialize_model(serialize_model(original))
+        assert restored.validate() == []
+
+    def test_round_trip_constraint_required_enforced(self) -> None:
+        """The 'required' constraint declared abstractly is preserved through XML.
+
+        Drop an _owner from one element after round-trip and confirm validate()
+        flags it — proving the constraint reached the restored profile.
+        """
+        original = self._build()
+        restored = deserialize_model(serialize_model(original))
+        # Strip _owner from one element to provoke the required-check.
+        target = next(e for e in restored.elements if isinstance(e, ApplicationComponent))
+        target.extended_attributes.pop("_owner", None)
+        errors = [str(e) for e in restored.validate()]
+        assert any("_owner" in msg and "required" in msg for msg in errors), errors
+
+    def test_concrete_override_wins_on_collision(self) -> None:
+        """When both Element and a concrete type declare the same attr, the
+        concrete declaration must win (matching Profile.get_constraints
+        last-declared-wins semantics)."""
+        from etcion.metamodel.concepts import Element
+
+        m = Model()
+        comp = ApplicationComponent(name="App", extended_attributes={"_owner": 42})
+        m.add(comp)
+        m.apply_profile(
+            Profile(
+                name="Mixed",
+                attribute_extensions={
+                    Element: {"_owner": str},
+                    ApplicationComponent: {"_owner": int},  # later wins
+                },
+            )
+        )
+        root = serialize_model(m).getroot()
+        pd_container = root.find(f"{{{ARCHIMATE_NS}}}propertyDefinitions")
+        assert pd_container is not None
+        type_by_id = {pd.get("identifier"): pd.get("type") for pd in pd_container}
+        # int -> XSD "number"; if Element's str had won we'd see "string".
+        assert type_by_id["propdef-ApplicationComponent-_owner"] == "number"


### PR DESCRIPTION
## Summary
- `write_model` / `serialize_model` no longer raise `KeyError` when a `Profile` declares `attribute_extensions` against an abstract base (`Element`, `Relationship`, or `Concept`). Abstract keys are fanned out to one property definition per concrete concept type present in the model, matching `Profile.get_constraints`' subclass-aware semantics on the validation side.
- Concrete keys pass through unchanged. On `(type, attr)` collisions the later-declared entry wins, mirroring `Profile.get_constraints` merge order.
- After a round-trip the reconstructed profile is keyed on the concrete types rather than the original abstract base — semantically equivalent for elements present in the model, and the tradeoff the issue body endorses.

Closes #110.

## Test plan
- [x] `pytest test/serialization/test_xml.py::TestIssue110ElementKeyedProfile` (5 new cases): serialize doesn't raise; one propdef per concrete element type present; no leaked abstract-base propdef; round-trip `validate()` passes; `required` constraint preserved through XML; concrete declaration wins over abstract on attr-name collision.
- [x] `pytest test/serialization/test_xml.py` — full XML suite green.
- [x] `pytest --ignore=test/test_packaging.py` — full suite green (packaging tests require `twine`, not installed locally).
- [x] `ruff check`, `ruff format --check`, `mypy src/etcion/serialization/xml.py` — clean.

## Side-finding (out of scope, worth filing separately)
The `<etcion:profileConstraints>` sidecar fails XSD validation (`"This element is not expected"`) whenever any profile uses dict-form constraints — reproduced on a plain `Serving`-keyed profile with no abstract bases involved, so it is pre-existing and unrelated to this fix.