### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.13.0] - 15 Jun 2026
+## [Unreleased]
 
 Structural sharing for impact analysis and model editing
 ([ADR-051](docs/adr/ADR-051-copy-on-write-result-models.md), closes #113).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 15 Jun 2026
+
+Structural sharing for impact analysis and model editing
+([ADR-051](docs/adr/ADR-051-copy-on-write-result-models.md), closes #113).
+`analyze_impact` (and `chain_impacts`) no longer deep-copy the entire model to
+build `resulting_model`; a single-concept operation is now `O(affected)` rather
+than `O(model_size)`. A 1-element remove on a 150K-concept model drops from the
+multi-second range to ~1s (dominated by graph construction, not copying), and a
+rename on the same model is ~6ms.
+
+### Breaking changes
+
+- **Concepts are now immutable (frozen).** `elem.name = "x"` and other
+  post-construction attribute assignments raise `ValidationError`. Produce an
+  edited concept with `concept.model_copy(update={"name": "x"})` instead.
+  Isolation between a model and an impact `resulting_model` is now guaranteed by
+  immutability (shared instances cannot mutate) rather than by deep copying.
+- **`resulting_model` shares untouched concepts by reference.** Untouched
+  survivors in `ImpactResult.resulting_model` are now the *same* objects as in
+  the source model, not distinct copies. Code relying on object distinctness
+  (`id()` inequality) must instead rely on immutability for isolation.
+- **Relationship endpoints are addressed by ID.** `Relationship.source` /
+  `target` (object references) are replaced by `source_id` / `target_id`
+  strings. Resolve an endpoint to its concept via the owning model, e.g.
+  `model[rel.source_id]`. Construction still accepts `source=` / `target=` as a
+  `Concept` (or bare ID string) for convenience. The JSON/XML wire format is
+  unchanged (endpoints remain bare ID strings under `source`/`target`).
+- **`extended_attributes` is an immutable mapping (`FrozenMap`).** In-place
+  mutation (`concept.extended_attributes["k"] = v`) raises. Reads (`.get`,
+  iteration, `in`, `.items()`) are unchanged; serialization still emits a plain
+  `dict`. Set attributes at construction or via `model_copy(update=...)`.
+- **Element collection fields are immutable tuples.** `assigned_elements` and
+  `members` are now `tuple[...]` instead of `list[...]`.
+
 ## [0.12.0] - 02 Jun 2026
 
 ### Behavior changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ rename on the same model is ~6ms.
 
 ### Added
 
+- **`analyze_impact(substitute=(old, new))`** — *substitute/version* semantics
+  for replacement, complementing `replace=` (*redirect*). `new` takes over
+  `old`'s identity slot (registered under `old`'s ID), so relationships are left
+  untouched and resolve to `new`. Each relationship incident to `old` is
+  re-checked against `new`'s type and reported in `violations` if it becomes
+  impermissible; `old`'s direct neighbours are reported as affected at depth 1.
+  `replace=` is unchanged (it removes `old` and rewires its relationships onto
+  `new`).
 - **Structural-sharing editing API on `Model`**: `with_added(concept)`,
   `with_replaced(concept)`, and `with_removed(concept_or_id)` each return a new
   immutable `Model` that shares unchanged concept instances with the source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ rename on the same model is ~6ms.
 - **Element collection fields are immutable tuples.** `assigned_elements` and
   `members` are now `tuple[...]` instead of `list[...]`.
 
+### Added
+
+- **Structural-sharing editing API on `Model`**: `with_added(concept)`,
+  `with_replaced(concept)`, and `with_removed(concept_or_id)` each return a new
+  immutable `Model` that shares unchanged concept instances with the source
+  model. `with_replaced` is the cheap-edit primitive — combined with
+  `concept.model_copy(update={...})` it renames/edits a concept in roughly
+  constant time regardless of model size, with no relationship re-linking
+  (endpoints resolve by ID). `with_removed` also drops relationships left
+  dangling by the removal. Views are not carried into the new model (a `View`
+  binds to a specific model instance).
+
 ## [0.12.0] - 02 Jun 2026
 
 ### Behavior changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.0] - 15 Jun 2026
 
 Structural sharing for impact analysis and model editing
 ([ADR-051](docs/adr/ADR-051-copy-on-write-result-models.md), closes #113).

--- a/docs/adr/ADR-051-copy-on-write-result-models.md
+++ b/docs/adr/ADR-051-copy-on-write-result-models.md
@@ -2,7 +2,7 @@
 
 **Status:** ACCEPTED
 **Date:** 2026-06-15
-**Implemented in:** 0.13.0 — Decisions 1–7 shipped (frozen concepts, structural-sharing result models, ID-ref endpoints, unified COW builder, graph-cache invalidation). Decision 8 (public model-editing API on top of the now-cheap edit foundation) is a tracked follow-up; `replace` currently performs *redirect* semantics only (Decision 5's *substitute/version* mode is not yet exposed).
+**Implemented in:** 0.13.0 — Decisions 1–8 shipped (frozen concepts, structural-sharing result models, ID-ref endpoints, unified COW builder, graph-cache invalidation, and a structural-sharing editing API: `Model.with_added` / `with_replaced` / `with_removed`). Remaining follow-up: Decision 5's *substitute/version* mode for `analyze_impact(replace=...)` is not yet exposed — `replace` currently performs *redirect* semantics only.
 **Scope:** How `analyze_impact()` / `chain_impacts()` produce isolated result models, and how the metamodel supports cheap model editing, so that the cost of an operation scales with the *affected* set rather than total model size. Supersedes Decision 1 and Consequence "Negative #2" of [ADR-043](ADR-043-impact-analysis-engine.md); revisits relationship endpoint storage from [ADR-007](ADR-007-element-relationship-abcs.md) / [ADR-041](ADR-041-networkx-graph-conversion.md).
 
 ## Context

--- a/docs/adr/ADR-051-copy-on-write-result-models.md
+++ b/docs/adr/ADR-051-copy-on-write-result-models.md
@@ -1,7 +1,8 @@
 # ADR-051: Structural Sharing for Impact Analysis and Model Editing
 
-**Status:** PROPOSED
+**Status:** ACCEPTED
 **Date:** 2026-06-15
+**Implemented in:** 0.13.0 — Decisions 1–7 shipped (frozen concepts, structural-sharing result models, ID-ref endpoints, unified COW builder, graph-cache invalidation). Decision 8 (public model-editing API on top of the now-cheap edit foundation) is a tracked follow-up; `replace` currently performs *redirect* semantics only (Decision 5's *substitute/version* mode is not yet exposed).
 **Scope:** How `analyze_impact()` / `chain_impacts()` produce isolated result models, and how the metamodel supports cheap model editing, so that the cost of an operation scales with the *affected* set rather than total model size. Supersedes Decision 1 and Consequence "Negative #2" of [ADR-043](ADR-043-impact-analysis-engine.md); revisits relationship endpoint storage from [ADR-007](ADR-007-element-relationship-abcs.md) / [ADR-041](ADR-041-networkx-graph-conversion.md).
 
 ## Context

--- a/docs/adr/ADR-051-copy-on-write-result-models.md
+++ b/docs/adr/ADR-051-copy-on-write-result-models.md
@@ -1,0 +1,112 @@
+# ADR-051: Structural Sharing for Impact Analysis and Model Editing
+
+**Status:** PROPOSED
+**Date:** 2026-06-15
+**Scope:** How `analyze_impact()` / `chain_impacts()` produce isolated result models, and how the metamodel supports cheap model editing, so that the cost of an operation scales with the *affected* set rather than total model size. Supersedes Decision 1 and Consequence "Negative #2" of [ADR-043](ADR-043-impact-analysis-engine.md); revisits relationship endpoint storage from [ADR-007](ADR-007-element-relationship-abcs.md) / [ADR-041](ADR-041-networkx-graph-conversion.md).
+
+## Context
+
+[ADR-043](ADR-043-impact-analysis-engine.md) (Decision 1) builds every result model by iterating **all** of the original's concepts and deep-copying each survivor via `concept.model_copy(deep=True)`, then re-linking relationships to the copies. This is `_build_result_model()` in `src/etcion/impact.py:236`; `_analyze_merge()` reimplements the same full clone inline (`impact.py:357`).
+
+Issue [#113](https://github.com/korpodevs/etcion/issues/113) reports that this dominates wall time on large models. The work is `O(model_size)` per operation regardless of how few concepts the operation touches, and it compounds linearly in `chain_impacts()`. Profiling a single 1-element `remove` on a 100K-element model: ~88% of wall time in `_build_result_model`, ~6–8s extrapolated, attributable to ~250K `pydantic model_copy` calls. Reported scaling: ~0.18s / 0.30s / 0.65s at 1K / 5K / 10K elements for a one-element change.
+
+Confirmed against the code:
+
+- The deep copy at `impact.py:260` / `:274` runs over the **entire** concept set; `exclude_ids` drops only a handful.
+- BFS narrowing (`max_depth`, `follow_types`) shrinks only the `affected` set (`impact.py:662`); the copy at the `remove` branch (`impact.py:689`) is unconditional. This matches the report that narrowing traversal does not reduce latency.
+- `affected` and `broken_relationships` are computed from BFS on the original graph plus a membership scan — they do **not** depend on `resulting_model`. The deep copy serves only `resulting_model`.
+
+### Why the deep copy exists — it is a contract, not an accident
+
+ADR-043 Decision 6 and Consequence "Positive #1" promise a *fully isolated, immutable* result model so that `diff_models(original, resulting_model)` is safe. Issue #12's `TestResultModelDeepCopy` (`test/test_impact.py:719-823`) locks this down with three assertions: untouched survivors are **distinct objects** (`id()` inequality); surviving relationships reference the **new** copies; and mutating the original after analysis must not bleed into the result.
+
+So the per-op cost and the isolation guarantee are the *same thing*. The copy is slow because it is the mechanism enforcing isolation. The decision this ADR makes is therefore not "copy faster" but "achieve the same isolation guarantee without materializing every object."
+
+### The root cause behind every cheaper alternative we rejected
+
+We explored several lighter-weight options (recorded under Alternatives). Each had a tail:
+
+- **Opt-in / lazy `resulting_model`** defers or skips the copy but does not make materialization cheap; first access still pays `O(model_size)`.
+- **Lazy** introduces a stale-read hazard (the original mutating between analysis and first access), which we'd patch with a **version stamp** — but the stamp is unsound today because in-place concept field edits are invisible to the `Model` (only `add()` bumps state, `model.py:66`).
+- **Structural sharing without immutability** is simply unsafe: a shared concept mutated through one side bleeds into the other.
+
+The common root is **mutable concepts**. Every patch was working around their absence of immutability. Making concepts immutable removes the root cause and makes the rest fall out cleanly.
+
+## Decision
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Reframe isolation from "distinct objects" to "no cross-snapshot mutation."** The guarantee becomes: nothing observed through `resulting_model` can be changed to affect the original, or vice versa — enforced by immutability, not by copying. | The copy exists only to prevent mutation bleed. If concepts cannot be mutated, untouched instances may be shared by reference with zero risk. Isolation by "can't change it" replaces isolation by "own copy." |
+| 2 | **Make `Concept` instances frozen.** Add `frozen=True` to `Concept.model_config` (`concepts.py:46`) and make `extended_attributes` an immutable mapping (`concepts.py:53`). Editing produces new instances via `model_copy(update=...)`. | Frozen pydantic models forbid attribute assignment, so a shared untouched instance cannot be mutated through any model. The mutable `extended_attributes` dict is the sharpest aliasing hazard and must be frozen too. This is the enabler for all structural sharing — the standard precondition for persistent data structures (Clojure, Scala, Immutable.js, git's object model). |
+| 3 | **Relationship endpoints are stored by ID, not object reference.** Change `Relationship.source`/`target` (`concepts.py:116`) to `source_id`/`target_id` strings resolved through the owning model's registry; provide `source`/`target` accessors that resolve via the model. Identity-based graph queries (`Model.connected_to`/`sources_of`/`targets_of`, `model.py:262-272`) move from `is`-identity to ID equality. | ID endpoints decouple a relationship from the *instance* of its endpoint. A field edit (rename, attribute change) keeps the endpoint's ID stable, so **no relationship needs copying** — the registry maps the unchanged ID to the new instance. Object references would force re-linking every incident relationship for even a rename. |
+| 4 | **Build result/edited models copy-on-write: shallow-copy the registry, surgically apply the delta, share the rest.** The new `Model` shares all untouched concept instances by reference and copies only concepts an operation adds / removes / relinks. | A 1-element remove on 100K shares 99,999 elements; the registry shallow copy is ~100K pointer copies (sub-millisecond) versus ~250K pydantic deep copies (~6–8s). Cost becomes `O(affected + structural)`. |
+| 5 | **Define `replace` semantics explicitly via the two ID operations.** *Substitute/version* ("B occupies A's identity slot"): register B under A's ID; relationships are untouched — `O(1)`. *Redirect* ("B is a different entity"): rewrite A's incident relationships' endpoint IDs A→B and drop A — `O(degree(A))`. The API names which it does; it does not silently pick. | The two have different meaning. Versioning the same logical component wants the slot semantics; replacing with a genuinely different component wants redirect. ID endpoints make both expressible and cheap; only the redirect copies relationships, and only the incident ones. |
+| 6 | **Unify all operations through one COW builder; delete the inline clone in `_analyze_merge()`.** `remove`, `remove_relationship`, `add_relationship`, `merge`, `replace`, and the editing API all route through the same registry-overlay machinery. | ADR-043 Consequence "Negative #3" already mandated one shared helper. The merge path's inline duplicate (`impact.py:357-432`) currently pays the full cost independently; folding it in fixes merge/replace for free and removes a divergent path. |
+| 7 | **COW models never inherit a stale graph cache.** A model produced by COW starts with `_nx_graph = None` (`model.py:49`) so traversal recomputes against the actual surviving set; the immutable graph may itself be shared once computed. | The cache holds node attrs with back-references to concept instances (`model.py:244`). A shared/stale cache pointing at originals — including logically removed concepts — is a silent correctness bug. |
+| 8 | **Editing happens through `ModelBuilder` (mutable draft) → immutable `Model` (committed snapshot).** Direct field mutation of a committed concept raises; structural edits go through builder/COW APIs that return new models sharing structure. | Hides immutability behind a familiar mutable API at edit time (the Immer / `StringBuilder` pattern) and freezes only at commit. `ModelBuilder` already exists and is the dominant construction path. Fits a versioned, "new iteration" mental model where each edit yields a new model sharing structure with its predecessor. |
+
+## Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| **Keep the deep copy; micro-optimize the constant factor** (`model_construct`, skip validators, benchmarked `copy.deepcopy`) | Real, cheap, contract-preserving — could plausibly bring 100K to ~1s — but still `O(model_size)`. A good *interim* mitigation, not the asymptotic fix #113 asks for. Worth doing first if the freeze is deferred. |
+| **Opt-in `resulting_model` (`build_result=False`)** | Eliminates the copy for diagnostics-only callers and preserves snapshot-at-analysis semantics, but does nothing for callers that need the materialized model — they still pay `O(model_size)`. Complementary, not a substitute; subsumed once structural sharing makes materialization cheap. |
+| **Lazy `resulting_model` + version stamp** | Defers the copy and (with a monotonic `_version` counter) detects stale reads via the iterator-invalidation / optimistic-concurrency pattern. But it does not cheapen materialization, and the stamp is unsound without tracking in-place field edits, which the model cannot currently see (only `add()` bumps state). Frozen concepts dissolve the staleness hazard entirely (a frozen original cannot change), making the stamp unnecessary. |
+| **Write-lock the original until `resulting_model` is read** | The borrow-checker / `RefCell` pattern. Ergonomically poor in Python: leaks if never read, and `model.add(x)` raising because of an unrelated unread result is spooky action at a distance. Detection beats prevention for read-heavy workloads. |
+| **Structural sharing without freezing concepts** | Unsafe: a shared instance mutated through one model bleeds into the other. Sharing is sound only on immutable nodes. |
+| **Keep object-reference endpoints under the freeze** | Works for remove/impact (drop broken relationships, share the rest) but forces re-linking every incident relationship on a plain rename, because the *instance* changed. ID endpoints make field edits `O(1)`. |
+
+## Consequences
+
+### What changes for users (read carefully)
+
+This is a **behavioral contract change**, not a transparent optimization:
+
+1. **Untouched concepts in `resulting_model` are now the same objects as in the original** (shared by reference), not distinct copies. Code relying on `id()` distinctness — including the current `TestResultModelDeepCopy` assertions — must be rewritten to assert *mutation isolation* instead of object distinctness.
+2. **Concepts are read-only.** `elem.name = "x"` raises; edits go through `model_copy(update=...)`, a builder, or the COW editing API. This is the trade: read-only concepts in exchange for `O(affected)` cost and free isolation.
+3. **Relationship endpoints are addressed by ID.** Code reading `rel.source` continues to work via accessors, but anything depending on `is`-identity of endpoints or constructing relationships with raw object references changes.
+4. **`replace` requires choosing substitute-vs-redirect semantics** (Decision 5) where it was previously implicit.
+
+### Positive
+
+- Single-concept operations on a 100K model go from seconds to sub-second; `chain_impacts` drops from `O(ops × model_size)` to `O(ops × affected)`.
+- Field edits (rename, attribute change) become `O(1)` via ID endpoints.
+- Isolation becomes a structural guarantee (immutability) rather than a copy-enforced convention — stronger and harder to violate by accident.
+- The staleness, version-stamp, and lazy-safety problems dissolve rather than needing patches: a frozen original cannot change after analysis.
+- One unified result/edit builder; the divergent inline clone in `_analyze_merge` is deleted.
+- `diff_models()` and serialization are unaffected (they read by value/ID).
+
+### Negative / costs
+
+- **Freezing `Concept` is a metamodel-wide change.** Every post-construction mutation site (builders, profile/`extended_attributes` writes, validators, tests) must be audited and moved to copy-or-builder. This is the main reason this is PROPOSED — the audit blast radius must be measured before acceptance and may warrant a dedicated freeze ADR.
+- **ID endpoints are a wide refactor:** endpoint construction, serialization round-trips, and the identity-based graph queries (`model.py:262-272`) all change from object identity to ID equality.
+- **`frozen=True` makes models hashable by default and blocks `setattr`;** the mutable `extended_attributes` dict must become an immutable mapping and nothing may rely on in-place mutation or identity-hashing.
+- The Issue #12 tests must be migrated from "distinct object" semantics to "mutation isolation" semantics — a contract renegotiation.
+
+### Open questions for the review
+
+- **Freeze scope:** RESOLVED — **global freeze.** The audit (see "Freeze Audit" below) found `src/` already free of post-construction concept mutation, so freezing `Concept` globally is tractable; a result-only snapshot type would be unnecessary machinery.
+- **`extended_attributes` immutability mechanism:** *What this question is actually asking.* `frozen=True` stops rebinding the field (`concept.extended_attributes = {...}`) but **not** in-place mutation of the dict it points at (`concept.extended_attributes["k"] = v`). Under structural sharing two models can hold the *same* concept instance, hence the *same* dict object, so an in-place write through one model bleeds into the other. To close that hole the **container itself** must be immutable, not just the field binding. The open decision is which representation, and how to wire the three touchpoints it must survive:
+    - top-level freeze plus a documented "don't mutate nested values" contract unless a concrete need for deep-freeze appears. Also verify `MappingProxyType` survives `copy.deepcopy`/`pickle` for the `model_copy(deep=True)` path.
+- **Sequencing:** ship the constant-factor copy optimization first (cheap, contract-preserving) to relieve the immediate pain, then land freeze + ID endpoints as the asymptotic fix? Or go straight to the structural change?
+    - Go straight to the structural change
+- **Registry representation:** a plain dict shallow-copied per operation (simple, `O(size)` pointer copy) vs. a persistent/HAMT map (true `O(affected)`, more machinery). The shallow dict is almost certainly sufficient at the 100K ceiling.
+    - Resist over engineering and stick a plain dict to shallow-copied per operation
+
+## Freeze Audit (2026-06-15)
+
+A sweep of `src/` (~10.7K LOC, 41 modules) and `test/` for post-construction concept mutation. **Verdict: tractable — no intractable blockers.** The library is already written in an immutable, copy-on-write style for concepts; the freeze is largely a config change plus a localized test migration.
+
+**`src/` is clean:**
+
+- **No concept field mutation.** The only `.name/.description =` assignments (`patterns.py:1112/1174/1225`) are on `AntiPatternRule`/`RequiredPatternRule` (validation-rule classes), not `Concept` subclasses. No `.source`/`.target`/`.id` reassignment, no `setattr`. Editing already flows through constructors and `model_copy(update=...)` (impact.py, merge.py, viewpoints.py).
+- **All five `model_validator(mode="after")` are read-only** (`business.py:76`, `technology.py:82`, `application.py:58`, `elements.py:71`, `profiles.py:173`) — length checks that raise or `return self`; none mutate `self`, so none conflict with `frozen=True`.
+- **`extended_attributes` is never mutated in place in `src/`.** Every reference is a read or a construction-time kwarg (`provenance.py:19`; `xml.py` builds a local dict and passes it to the constructor). Provenance is *set at construction*, not written after.
+- **Hashability is a non-issue.** `frozen=True` generates `__hash__`, which would raise on a concept's `dict`/`list` fields only *if hashed* — but nothing hashes concepts; all lookups key on `c.id` (string), e.g. `comparison.py:210`, `merge.py:345`. The `set[type[Concept]]` usages are sets of *types*, not instances.
+
+**Two real work items (cost, not blockers):**
+
+- **Test migration — small and localized (~15–20 lines, ~6 files):** field mutations at `test/e2e/test_analytical_workflows.py:373/388/491/492` and two already-`# type: ignore`d viewpoint tests; in-place `extended_attributes` writes at `test_serialization_matrix.py:72`, `test_model_lifecycle.py:96/460`, `test_xml.py:1204`; and the `TestResultModelDeepCopy` contract tests (`test_impact.py:719-823`, plus `:858`) rewritten from `id()`-inequality to mutation-isolation semantics (the expected ADR-043 renegotiation).
+- **Mutable collection fields — a second aliasing surface:** beyond `extended_attributes`, concepts carry `assigned_elements: list[...]` (4 collaboration/interaction types) and `members: list[Concept]` (`elements.py:100`). `frozen=True` blocks field reassignment but not in-place list mutation; these should become `tuple`/immutable for sharing safety (no in-place `.append` found in `src/`, so it is a type change, not a redesign).
+
+**Adjacent and separable:** ID-ref endpoints (Decision 3) are a wider refactor independent of the freeze. `frozen=True` can land first (closing the isolation gap and enabling shared untouched concepts in impact analysis); ID-refs follow to make *editing* cheap.

--- a/docs/adr/ADR-051-copy-on-write-result-models.md
+++ b/docs/adr/ADR-051-copy-on-write-result-models.md
@@ -2,7 +2,7 @@
 
 **Status:** ACCEPTED
 **Date:** 2026-06-15
-**Implemented in:** 0.13.0 — Decisions 1–8 shipped (frozen concepts, structural-sharing result models, ID-ref endpoints, unified COW builder, graph-cache invalidation, and a structural-sharing editing API: `Model.with_added` / `with_replaced` / `with_removed`). Remaining follow-up: Decision 5's *substitute/version* mode for `analyze_impact(replace=...)` is not yet exposed — `replace` currently performs *redirect* semantics only.
+**Implemented in:** 0.13.0 — Decisions 1–8 shipped in full: frozen concepts, structural-sharing result models, ID-ref endpoints, unified COW builder, graph-cache invalidation, the structural-sharing editing API (`Model.with_added` / `with_replaced` / `with_removed`), and both replace modes from Decision 5 — `analyze_impact(replace=...)` (*redirect*) and `analyze_impact(substitute=...)` (*substitute/version*).
 **Scope:** How `analyze_impact()` / `chain_impacts()` produce isolated result models, and how the metamodel supports cheap model editing, so that the cost of an operation scales with the *affected* set rather than total model size. Supersedes Decision 1 and Consequence "Negative #2" of [ADR-043](ADR-043-impact-analysis-engine.md); revisits relationship endpoint storage from [ADR-007](ADR-007-element-relationship-abcs.md) / [ADR-041](ADR-041-networkx-graph-conversion.md).
 
 ## Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "etcion"
-version = "0.13.0"
+version = "0.12.0"
 description = "Architecture as code — build, query, validate, and analyze enterprise architecture models in Python"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "etcion"
-version = "0.12.0"
+version = "0.13.0"
 description = "Architecture as code — build, query, validate, and analyze enterprise architecture models in Python"
 readme = "README.md"
 license = "MIT"

--- a/src/etcion/builder.py
+++ b/src/etcion/builder.py
@@ -213,7 +213,9 @@ def _relationship_factory(cls: type[Relationship]) -> Any:  # noqa: ANN401
         self._check_not_built()
         src = self._resolve(source)
         tgt = self._resolve(target)
-        rel: cls = cls(source=src, target=tgt, name=name, **kwargs)  # type: ignore[valid-type]
+        src_id = src.id if isinstance(src, Concept) else src
+        tgt_id = tgt.id if isinstance(tgt, Concept) else tgt
+        rel: cls = cls(source_id=src_id, target_id=tgt_id, name=name, **kwargs)  # type: ignore[valid-type]
         self._concepts.append(rel)
         self._id_map[rel.id] = rel  # type: ignore[attr-defined]
         return rel

--- a/src/etcion/comparison.py
+++ b/src/etcion/comparison.py
@@ -176,8 +176,8 @@ def _normalize_dump(concept: Concept) -> dict[str, Any]:
     d = concept.model_dump()
     d.pop("id", None)
     if isinstance(concept, Relationship):
-        d["source"] = concept.source.id
-        d["target"] = concept.target.id
+        d["source"] = concept.source_id
+        d["target"] = concept.target_id
     return d
 
 

--- a/src/etcion/derivation/engine.py
+++ b/src/etcion/derivation/engine.py
@@ -61,19 +61,19 @@ class DerivationEngine:
             # Build adjacency list: source_id -> list of (target_concept, rel)
             adjacency: dict[str, list[Relationship]] = defaultdict(list)
             for rel in rels:
-                adjacency[rel.source.id].append(rel)
+                adjacency[rel.source_id].append(rel)
 
             # For each relationship A->B, look for B->C to derive A->C.
             # We only need one pass for two-hop chains (spec req for the tests);
             # the existing direct relationships already cover the one-hop case.
-            existing_pairs: set[tuple[str, str]] = {(r.source.id, r.target.id) for r in rels}
+            existing_pairs: set[tuple[str, str]] = {(r.source_id, r.target_id) for r in rels}
 
             for rel_ab in rels:
-                intermediate_id = rel_ab.target.id
+                intermediate_id = rel_ab.target_id
                 if intermediate_id not in adjacency:
                     continue
                 for rel_bc in adjacency[intermediate_id]:
-                    pair = (rel_ab.source.id, rel_bc.target.id)
+                    pair = (rel_ab.source_id, rel_bc.target_id)
                     if pair in existing_pairs:
                         # Relationship already exists directly; skip.
                         continue
@@ -82,15 +82,15 @@ class DerivationEngine:
                         continue
                     existing_pairs.add(pair)
                     derived_name = (
-                        f"derived:{rel_type.__name__}:{rel_ab.source.id}->{rel_bc.target.id}"
+                        f"derived:{rel_type.__name__}:{rel_ab.source_id}->{rel_bc.target_id}"
                     )
                     # Cast to Any: rel_type is a concrete Relationship subclass
                     # that carries `name` via AttributeMixin, but mypy cannot
                     # resolve the mixin field through the abstract base type.
                     derived_rel: Relationship = cast(Any, rel_type)(
                         name=derived_name,
-                        source=rel_ab.source,
-                        target=rel_bc.target,
+                        source_id=rel_ab.source_id,
+                        target_id=rel_bc.target_id,
                         is_derived=True,
                     )
                     derived.append(derived_rel)

--- a/src/etcion/impact.py
+++ b/src/etcion/impact.py
@@ -236,50 +236,35 @@ def _find_rel_id(graph: object, node_a: str, node_b: str) -> str:
 def _build_result_model(original: Model, exclude_ids: set[str]) -> Model:
     """Build a new Model excluding concepts whose IDs are in *exclude_ids*.
 
-    Phase 1: Deep-copy all Elements and RelationshipConnectors (excluding IDs
-    in *exclude_ids*) and build an id→copy map.
-    Phase 2: Deep-copy each surviving Relationship, re-linking its ``source``
-    and ``target`` fields to the copies produced in Phase 1.  Relationships
-    whose source or target was excluded are skipped (they are broken).
-    Phase 3: Construct a new :class:`~etcion.metamodel.model.Model` from all
-    copied concepts.
+    Copy-on-write (ADR-051): concepts are immutable, so the result *shares* every
+    surviving concept instance by reference rather than deep-copying it.  Cost is
+    therefore ``O(model_size)`` in cheap pointer copies (shallow registry copy),
+    not ``O(model_size)`` pydantic deep copies.  Relationships left dangling by an
+    excluded endpoint are dropped (they are broken).  No re-linking is needed:
+    surviving relationships already reference the shared (unchanged) endpoint
+    instances.
+
+    The fresh :class:`~etcion.metamodel.model.Model` starts with an empty graph
+    cache, so traversal recomputes against the surviving set (ADR-051 Decision 7).
 
     :param original: The source model.
     :param exclude_ids: Set of concept IDs to omit from the result.
     :returns: A new :class:`~etcion.metamodel.model.Model` instance.
     """
-    from etcion.metamodel.concepts import Element, Relationship, RelationshipConnector
+    from etcion.metamodel.concepts import Relationship
     from etcion.metamodel.model import Model
 
-    # Phase 1 — copy Elements and RelationshipConnectors.
-    id_map: dict[str, Element | RelationshipConnector] = {}
-    for concept in original.concepts:
-        if concept.id in exclude_ids:
-            continue
-        if isinstance(concept, (Element, RelationshipConnector)):
-            id_map[concept.id] = concept.model_copy(deep=True)
-
-    # Phase 2 — copy Relationships with re-linked source/target.
-    copied_rels: list[Relationship] = []
-    for concept in original.concepts:
-        if concept.id in exclude_ids:
-            continue
-        if isinstance(concept, Relationship):
-            new_src = id_map.get(concept.source.id)
-            new_tgt = id_map.get(concept.target.id)
-            if new_src is None or new_tgt is None:
-                # Source or target was excluded; skip (broken relationship).
-                continue
-            copied_rels.append(
-                concept.model_copy(deep=True, update={"source": new_src, "target": new_tgt})
-            )
-
-    # Phase 3 — assemble the new Model.
     new_model = Model()
-    for copied in id_map.values():
-        new_model.add(copied)
-    for copied_rel in copied_rels:
-        new_model.add(copied_rel)
+    for concept in original.concepts:
+        if concept.id in exclude_ids:
+            continue
+        if isinstance(concept, Relationship) and (
+            concept.source.id in exclude_ids or concept.target.id in exclude_ids
+        ):
+            # Source or target was excluded; skip (broken relationship).
+            continue
+        # Share the immutable instance by reference (structural sharing).
+        new_model.add(concept)
     return new_model
 
 
@@ -352,18 +337,18 @@ def _analyze_merge(
         r for r in model.relationships if r.source.id in merged_ids or r.target.id in merged_ids
     ]
 
-    # Ensure target is in the id_map for the result model.
-    # Phase 1 — copy Elements and RelationshipConnectors, excluding remove_ids.
+    # Result model shares unchanged concept instances (ADR-051 structural
+    # sharing); only rewired relationships are copied (their endpoints change).
     id_map: dict[str, Element | RelationshipConnector] = {}
     for concept in model.concepts:
         if concept.id in remove_ids:
             continue
         if isinstance(concept, (Element, RelationshipConnector)):
-            id_map[concept.id] = concept.model_copy(deep=True)
+            id_map[concept.id] = concept
 
-    # If the target is not in the original model, add a copy.
+    # If the target is not in the original model, include it (shared).
     if target_id not in id_map and isinstance(target, (Element, RelationshipConnector)):
-        id_map[target_id] = target.model_copy(deep=True)
+        id_map[target_id] = target
 
     # Rewire touching relationships, then deduplicate.
     # Key: (rel_type, new_source_id, new_target_id) — first wins.
@@ -376,7 +361,7 @@ def _analyze_merge(
             new_src = id_map.get(new_src_id)
             new_tgt = id_map.get(new_tgt_id)
             if new_src is not None and new_tgt is not None:
-                rewired = rel.model_copy(deep=True, update={"source": new_src, "target": new_tgt})
+                rewired = rel.model_copy(update={"source": new_src, "target": new_tgt})
                 seen_keys[key] = rewired
 
     # Permission-check deduplicated rewired relationships.
@@ -407,20 +392,19 @@ def _analyze_merge(
                 )
             )
 
-    # Collect surviving (non-touching) relationships from the original model,
-    # copying and re-linking them via id_map.
+    # Surviving (non-touching) relationships are shared unchanged — their
+    # endpoints are not merged, so they still reference valid instances.
     surviving_rels: list[Relationship] = []
     touching_ids = {r.id for r in touching}
     for concept in model.concepts:
         if concept.id in remove_ids:
             continue
         if isinstance(concept, Relationship) and concept.id not in touching_ids:
-            new_src = id_map.get(concept.source.id)
-            new_tgt = id_map.get(concept.target.id)
-            if new_src is not None and new_tgt is not None:
-                surviving_rels.append(
-                    concept.model_copy(deep=True, update={"source": new_src, "target": new_tgt})
-                )
+            if (
+                id_map.get(concept.source.id) is not None
+                and id_map.get(concept.target.id) is not None
+            ):
+                surviving_rels.append(concept)
 
     # Assemble result model.
     result_model = _Model()
@@ -459,9 +443,9 @@ def _analyze_add_relationship(model: Model, relationship: Relationship) -> Impac
     new_src = result_model._concepts.get(relationship.source.id)
     new_tgt = result_model._concepts.get(relationship.target.id)
     if new_src is not None and new_tgt is not None:
-        new_rel = relationship.model_copy(deep=True, update={"source": new_src, "target": new_tgt})
+        new_rel = relationship.model_copy(update={"source": new_src, "target": new_tgt})
     else:
-        new_rel = relationship.model_copy(deep=True)
+        new_rel = relationship.model_copy()
     result_model.add(new_rel)
 
     # Affected: source and target elements at depth 1.

--- a/src/etcion/impact.py
+++ b/src/etcion/impact.py
@@ -137,8 +137,8 @@ class ImpactResult:
                 {
                     "id": r.id,
                     "type": type(r).__name__,
-                    "source_id": r.source.id,
-                    "target_id": r.target.id,
+                    "source_id": r.source_id,
+                    "target_id": r.target_id,
                 }
                 for r in self.broken_relationships
             ],
@@ -194,8 +194,10 @@ class ImpactResult:
                 "</tr>"
             )
             for rel in self.broken_relationships:
-                src_name = getattr(rel.source, "name", None) or rel.source.id
-                tgt_name = getattr(rel.target, "name", None) or rel.target.id
+                # Endpoints are addressed by ID (ADR-051); the result carries no
+                # model reference, so display the IDs directly.
+                src_name = rel.source_id
+                tgt_name = rel.target_id
                 parts.append(
                     f"<tr style='background:#f8d7da;'>"
                     f"<td style='padding:4px;'>{rel.id[:12]}...</td>"
@@ -259,7 +261,7 @@ def _build_result_model(original: Model, exclude_ids: set[str]) -> Model:
         if concept.id in exclude_ids:
             continue
         if isinstance(concept, Relationship) and (
-            concept.source.id in exclude_ids or concept.target.id in exclude_ids
+            concept.source_id in exclude_ids or concept.target_id in exclude_ids
         ):
             # Source or target was excluded; skip (broken relationship).
             continue
@@ -334,7 +336,7 @@ def _analyze_merge(
 
     # Collect all relationships touching any merged element.
     touching: list[Relationship] = [
-        r for r in model.relationships if r.source.id in merged_ids or r.target.id in merged_ids
+        r for r in model.relationships if r.source_id in merged_ids or r.target_id in merged_ids
     ]
 
     # Result model shares unchanged concept instances (ADR-051 structural
@@ -354,14 +356,14 @@ def _analyze_merge(
     # Key: (rel_type, new_source_id, new_target_id) — first wins.
     seen_keys: dict[tuple[type, str, str], Relationship] = {}
     for rel in touching:
-        new_src_id = target_id if rel.source.id in merged_ids else rel.source.id
-        new_tgt_id = target_id if rel.target.id in merged_ids else rel.target.id
+        new_src_id = target_id if rel.source_id in merged_ids else rel.source_id
+        new_tgt_id = target_id if rel.target_id in merged_ids else rel.target_id
         key = (type(rel), new_src_id, new_tgt_id)
         if key not in seen_keys:
             new_src = id_map.get(new_src_id)
             new_tgt = id_map.get(new_tgt_id)
             if new_src is not None and new_tgt is not None:
-                rewired = rel.model_copy(update={"source": new_src, "target": new_tgt})
+                rewired = rel.model_copy(update={"source_id": new_src_id, "target_id": new_tgt_id})
                 seen_keys[key] = rewired
 
     # Permission-check deduplicated rewired relationships.
@@ -401,8 +403,8 @@ def _analyze_merge(
             continue
         if isinstance(concept, Relationship) and concept.id not in touching_ids:
             if (
-                id_map.get(concept.source.id) is not None
-                and id_map.get(concept.target.id) is not None
+                id_map.get(concept.source_id) is not None
+                and id_map.get(concept.target_id) is not None
             ):
                 surviving_rels.append(concept)
 
@@ -427,31 +429,22 @@ def _analyze_add_relationship(model: Model, relationship: Relationship) -> Impac
     """Implement the add_relationship operation for :func:`analyze_impact`.
 
     Builds a result model consisting of all concepts from the original model
-    plus the new relationship (deep-copied with source/target re-linked to
-    copies of the original elements).  Reports source and target elements as
-    affected at depth 1.
+    plus the new relationship.  Endpoints are addressed by ID (ADR-051), so the
+    relationship needs no re-linking — its source_id/target_id already resolve
+    against the shared elements.  Reports source and target elements as affected
+    at depth 1.
 
     :param model: Source model.
     :param relationship: The relationship to add.
     :returns: :class:`ImpactResult` describing the add-relationship impact.
     """
-    from etcion.metamodel.model import Model as _Model
-
     result_model = _build_result_model(model, set())
-
-    # Re-link the new relationship's source/target to the copies in result_model.
-    new_src = result_model._concepts.get(relationship.source.id)
-    new_tgt = result_model._concepts.get(relationship.target.id)
-    if new_src is not None and new_tgt is not None:
-        new_rel = relationship.model_copy(update={"source": new_src, "target": new_tgt})
-    else:
-        new_rel = relationship.model_copy()
-    result_model.add(new_rel)
+    result_model.add(relationship.model_copy())
 
     # Affected: source and target elements at depth 1.
     affected: list[ImpactedConcept] = []
-    src_concept = result_model._concepts.get(relationship.source.id)
-    tgt_concept = result_model._concepts.get(relationship.target.id)
+    src_concept = result_model._concepts.get(relationship.source_id)
+    tgt_concept = result_model._concepts.get(relationship.target_id)
     if src_concept is not None:
         affected.append(ImpactedConcept(concept=src_concept, depth=1))
     if tgt_concept is not None:
@@ -481,8 +474,8 @@ def _analyze_remove_relationship(model: Model, relationship: Relationship) -> Im
 
     # Affected: source and target elements at depth 1 (copies in result model).
     affected: list[ImpactedConcept] = []
-    src_concept = result_model._concepts.get(relationship.source.id)
-    tgt_concept = result_model._concepts.get(relationship.target.id)
+    src_concept = result_model._concepts.get(relationship.source_id)
+    tgt_concept = result_model._concepts.get(relationship.target_id)
     if src_concept is not None:
         affected.append(ImpactedConcept(concept=src_concept, depth=1))
     if tgt_concept is not None:
@@ -665,7 +658,7 @@ def analyze_impact(
 
     # Identify broken relationships (any relationship touching the removed element).
     broken: tuple[Relationship, ...] = tuple(
-        r for r in model.relationships if r.source.id == start_id or r.target.id == start_id
+        r for r in model.relationships if r.source_id == start_id or r.target_id == start_id
     )
 
     # Build result model excluding the removed element and all broken relationships.

--- a/src/etcion/impact.py
+++ b/src/etcion/impact.py
@@ -425,6 +425,71 @@ def _analyze_merge(
     )
 
 
+def _analyze_substitute(model: Model, old: Concept, new: Concept) -> ImpactResult:
+    """Implement the substitute/version operation for :func:`analyze_impact`.
+
+    *new* takes over *old*'s identity slot: it is registered under ``old.id`` so
+    that relationships -- which reference endpoints by ID (ADR-051) -- are left
+    untouched and resolve to *new*.  This is an ``O(1)`` structural edit (plus a
+    shallow registry copy).
+
+    Each relationship incident to ``old.id`` is re-checked against *new*'s type
+    and reported in ``violations`` if it becomes impermissible.  ``old``'s direct
+    neighbours are reported as affected at depth 1.
+
+    :param model: Source model.
+    :param old: The concept whose identity slot is being filled.
+    :param new: The replacement concept (re-keyed to ``old.id`` if it differs).
+    :returns: :class:`ImpactResult` describing the substitution.
+    """
+    from etcion.metamodel.concepts import Element
+    from etcion.validation.permissions import is_permitted
+
+    # new occupies old's identity slot.
+    new_keyed = new if new.id == old.id else new.model_copy(update={"id": old.id})
+    resulting_model = model.with_replaced(new_keyed)
+
+    incident = model.connected_to(old)
+
+    # Affected: old's direct neighbours (now connected to new) at depth 1.
+    affected: list[ImpactedConcept] = []
+    seen: set[str] = set()
+    for rel in incident:
+        other_id = rel.target_id if rel.source_id == old.id else rel.source_id
+        other = model._concepts.get(other_id)
+        if other is not None and other.id != old.id and other.id not in seen:
+            seen.add(other.id)
+            affected.append(ImpactedConcept(concept=other, depth=1))
+
+    # Violations: relationships whose permission breaks now that they connect to
+    # new's type instead of old's. Only element-to-element rels are checked.
+    violations: list[Violation] = []
+    for rel in incident:
+        src = new_keyed if rel.source_id == old.id else model._concepts.get(rel.source_id)
+        tgt = new_keyed if rel.target_id == old.id else model._concepts.get(rel.target_id)
+        if not isinstance(src, Element) or not isinstance(tgt, Element):
+            continue
+        if not is_permitted(type(rel), type(src), type(tgt)):
+            violations.append(
+                Violation(
+                    relationship=rel,
+                    reason=(
+                        f"{type(rel).__name__}("
+                        f"{type(src).__name__} -> {type(tgt).__name__}) is not permitted "
+                        f"by ArchiMate 3.2 Appendix B after substituting "
+                        f"{type(old).__name__} with {type(new).__name__}"
+                    ),
+                )
+            )
+
+    return ImpactResult(
+        affected=tuple(affected),
+        broken_relationships=(),
+        resulting_model=resulting_model,
+        violations=tuple(violations),
+    )
+
+
 def _analyze_add_relationship(model: Model, relationship: Relationship) -> ImpactResult:
     """Implement the add_relationship operation for :func:`analyze_impact`.
 
@@ -532,6 +597,7 @@ def analyze_impact(
     remove: Concept | None = None,
     merge: tuple[list[Concept], Concept] | None = None,
     replace: tuple[Concept, Concept] | None = None,
+    substitute: tuple[Concept, Concept] | None = None,
     add_relationship: Relationship | None = None,
     remove_relationship: Relationship | None = None,
     max_depth: int | None = None,
@@ -556,10 +622,18 @@ def analyze_impact(
     :param merge: A ``(merged_list, target)`` tuple.  All concepts in
         ``merged_list`` are collapsed into ``target``.  Relationships are
         rewired, deduplicated, and permission-checked.
-    :param replace: A ``(old, new)`` tuple.  ``old`` is removed from the
-        model and all its relationships are transferred to ``new``.
-        Equivalent to ``merge([old], new)`` and subject to the same
-        permission-checking logic.
+    :param replace: A ``(old, new)`` tuple — *redirect* semantics.  ``old`` is
+        removed and its relationships are rewired onto ``new`` (a different
+        entity).  Equivalent to ``merge([old], new)`` and subject to the same
+        permission-checking logic.  Use ``substitute`` instead when ``new`` is a
+        new *version* of ``old`` that should keep ``old``'s identity.
+    :param substitute: A ``(old, new)`` tuple — *substitute/version* semantics.
+        ``new`` takes over ``old``'s identity slot (it is registered under
+        ``old``'s ID), so relationships are left untouched — they resolve the
+        unchanged ID to ``new``.  Each relationship incident to ``old`` is
+        re-checked against ``new``'s type and reported in ``violations`` if it
+        becomes impermissible.  ``old``'s direct neighbours are reported as
+        affected at depth 1.
     :param add_relationship: A :class:`~etcion.metamodel.concepts.Relationship`
         to hypothetically add to the model.  The resulting model contains all
         original concepts plus this new relationship.  The source and target
@@ -582,6 +656,7 @@ def analyze_impact(
         remove is None
         and merge is None
         and replace is None
+        and substitute is None
         and add_relationship is None
         and remove_relationship is None
     ):
@@ -594,10 +669,15 @@ def analyze_impact(
             "networkx is required for impact analysis. Install it with: pip install etcion[graph]"
         ) from None
 
-    # Dispatch replace operation — delegate to merge with a single-element list.
+    # Dispatch replace operation (redirect) — delegate to merge with a single-element list.
     if replace is not None:
         old, new = replace
         return _analyze_merge(model, [old], new)
+
+    # Dispatch substitute operation (version) — new takes old's identity slot.
+    if substitute is not None:
+        old, new = substitute
+        return _analyze_substitute(model, old, new)
 
     # Dispatch merge operation.
     if merge is not None:

--- a/src/etcion/merge.py
+++ b/src/etcion/merge.py
@@ -281,8 +281,8 @@ def merge_models(
     dangling_violations: list[Violation] = []
 
     for rel in rels:
-        new_src = id_map.get(rel.source.id)
-        new_tgt = id_map.get(rel.target.id)
+        new_src = id_map.get(rel.source_id)
+        new_tgt = id_map.get(rel.target_id)
         if new_src is None or new_tgt is None:
             dangling_violations.append(
                 Violation(
@@ -290,12 +290,14 @@ def merge_models(
                     reason=(
                         f"Relationship '{rel.id}' has a dangling endpoint "
                         f"in the merged model "
-                        f"(source='{rel.source.id}', target='{rel.target.id}')"
+                        f"(source='{rel.source_id}', target='{rel.target_id}')"
                     ),
                 )
             )
             continue
-        copied_rels.append(rel.model_copy(deep=True, update={"source": new_src, "target": new_tgt}))
+        # Endpoints are addressed by ID (ADR-051); copies preserve them, so no
+        # re-linking of source/target is required.
+        copied_rels.append(rel.model_copy(deep=True))
 
     # ------------------------------------------------------------------
     # Step 5: assemble the merged Model.
@@ -386,8 +388,8 @@ def apply_diff(
     dangling: list[Violation] = []
 
     for rel in rels:
-        new_src = id_map.get(rel.source.id)
-        new_tgt = id_map.get(rel.target.id)
+        new_src = id_map.get(rel.source_id)
+        new_tgt = id_map.get(rel.target_id)
         if new_src is None or new_tgt is None:
             dangling.append(
                 Violation(
@@ -395,12 +397,14 @@ def apply_diff(
                     reason=(
                         f"Relationship '{rel.id}' has a dangling endpoint "
                         f"after diff application "
-                        f"(source='{rel.source.id}', target='{rel.target.id}')"
+                        f"(source='{rel.source_id}', target='{rel.target_id}')"
                     ),
                 )
             )
             continue
-        copied_rels.append(rel.model_copy(deep=True, update={"source": new_src, "target": new_tgt}))
+        # Endpoints are addressed by ID (ADR-051); copies preserve them, so no
+        # re-linking of source/target is required.
+        copied_rels.append(rel.model_copy(deep=True))
 
     # ------------------------------------------------------------------
     # Assemble the result Model.

--- a/src/etcion/metamodel/application.py
+++ b/src/etcion/metamodel/application.py
@@ -48,7 +48,7 @@ class ApplicationComponent(ApplicationInternalActiveStructureElement):
 
 
 class ApplicationCollaboration(ApplicationInternalActiveStructureElement):
-    assigned_elements: list[ActiveStructureElement] = Field(default_factory=list)
+    assigned_elements: tuple[ActiveStructureElement, ...] = Field(default_factory=tuple)
     notation: ClassVar[NotationMetadata] = NotationMetadata(
         corner_shape="square",
         layer_color="#B5FFFF",

--- a/src/etcion/metamodel/business.py
+++ b/src/etcion/metamodel/business.py
@@ -66,7 +66,7 @@ class BusinessRole(BusinessInternalActiveStructureElement):
 
 
 class BusinessCollaboration(BusinessInternalActiveStructureElement):
-    assigned_elements: list[ActiveStructureElement] = Field(default_factory=list)
+    assigned_elements: tuple[ActiveStructureElement, ...] = Field(default_factory=tuple)
     notation: ClassVar[NotationMetadata] = NotationMetadata(
         corner_shape="square",
         layer_color="#FFFFB5",

--- a/src/etcion/metamodel/concepts.py
+++ b/src/etcion/metamodel/concepts.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 import abc
 import uuid
 from abc import abstractmethod
-from typing import Any, ClassVar
+from collections.abc import Iterator, Mapping
+from typing import Any, ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from etcion.enums import RelationshipCategory
 from etcion.metamodel.mixins import AttributeMixin
@@ -28,9 +29,59 @@ from etcion.metamodel.mixins import AttributeMixin
 __all__: list[str] = [
     "Concept",
     "Element",
+    "FrozenMap",
     "Relationship",
     "RelationshipConnector",
 ]
+
+
+class FrozenMap(Mapping[str, Any]):
+    """Immutable mapping used for :attr:`Concept.extended_attributes`.
+
+    Concepts are frozen (ADR-051) so that a model produced by structural
+    sharing can reference unchanged concept instances rather than deep-copying
+    them.  ``frozen=True`` blocks *rebinding* a field, but a plain ``dict``
+    field could still be mutated in place through a shared instance, leaking
+    across the original/result boundary.  ``FrozenMap`` closes that hole: it
+    supports all read operations of a mapping and raises on writes.
+
+    Unlike :class:`types.MappingProxyType`, ``FrozenMap`` is ``deepcopy``- and
+    ``pickle``-able (via :meth:`__reduce__`), so it survives
+    ``model_copy(deep=True)`` -- the copy path used throughout impact analysis
+    and merge.
+    """
+
+    __slots__ = ("_data",)
+    _data: dict[str, Any]
+
+    def __init__(self, data: Mapping[str, Any] | None = None) -> None:
+        object.__setattr__(self, "_data", dict(data) if data else {})
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401 — values are arbitrary profile data
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, FrozenMap):
+            return self._data == other._data
+        if isinstance(other, Mapping):
+            return self._data == dict(other)
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self._data.items()))
+
+    def __repr__(self) -> str:
+        return f"FrozenMap({self._data!r})"
+
+    def __reduce__(self) -> tuple[type[FrozenMap], tuple[dict[str, Any]]]:
+        # Enables copy.deepcopy and pickle (mappingproxy cannot do this).
+        return (FrozenMap, (self._data,))
 
 
 class Concept(abc.ABC, BaseModel):
@@ -43,14 +94,14 @@ class Concept(abc.ABC, BaseModel):
     Reference: ArchiMate 3.2 Specification, Section 3.1.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid", frozen=True)
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     """Unique identifier.  Defaults to a UUID4 string.  Any non-empty string
     is accepted to support Archi-prefixed IDs (e.g. ``id-<uuid>``) and plain
     UUID strings from the Open Group Exchange Format."""
 
-    extended_attributes: dict[str, Any] = Field(default_factory=dict)
+    extended_attributes: FrozenMap = Field(default_factory=FrozenMap)
     """Arbitrary extended attributes declared by a
     :class:`~etcion.metamodel.profiles.Profile`.
 
@@ -61,8 +112,45 @@ class Concept(abc.ABC, BaseModel):
     profile's ``attribute_extensions`` schema is performed by
     :meth:`~etcion.metamodel.model.Model.validate`.
 
-    Reference: ADR-050.
+    Reference: ADR-050, ADR-051.
     """
+
+    @field_validator("extended_attributes", mode="before")
+    @classmethod
+    def _coerce_extended_attributes(cls, value: object) -> FrozenMap:
+        """Coerce any incoming mapping into an immutable :class:`FrozenMap`.
+
+        Runs at construction and on validated re-construction, so constructors
+        and deserialization paths may pass a plain ``dict`` and still get an
+        immutable mapping back.
+        """
+        if isinstance(value, FrozenMap):
+            return value
+        if value is None:
+            return FrozenMap()
+        if isinstance(value, Mapping):
+            return FrozenMap(value)
+        raise TypeError(f"extended_attributes must be a mapping, got {type(value).__name__}")
+
+    @field_serializer("extended_attributes")
+    def _serialize_extended_attributes(self, value: FrozenMap) -> dict[str, Any]:
+        """Emit ``extended_attributes`` as a plain ``dict`` for serialization."""
+        return dict(value)
+
+    def model_copy(self, *, update: Mapping[str, Any] | None = None, deep: bool = False) -> Self:
+        """Copy this concept, re-coercing ``extended_attributes`` if updated.
+
+        ``BaseModel.model_copy`` bypasses validation, so an ``extended_attributes``
+        value passed via *update* would otherwise be stored as a raw ``dict``.
+        This override re-wraps it in a :class:`FrozenMap` to preserve immutability
+        (ADR-051).
+        """
+        if update is not None and "extended_attributes" in update:
+            update = {
+                **update,
+                "extended_attributes": FrozenMap(update["extended_attributes"]),
+            }
+        return super().model_copy(update=dict(update) if update is not None else None, deep=deep)
 
     @property
     @abstractmethod

--- a/src/etcion/metamodel/concepts.py
+++ b/src/etcion/metamodel/concepts.py
@@ -21,7 +21,14 @@ from abc import abstractmethod
 from collections.abc import Iterator, Mapping
 from typing import Any, ClassVar, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from etcion.enums import RelationshipCategory
 from etcion.metamodel.mixins import AttributeMixin
@@ -190,21 +197,40 @@ class Element(AttributeMixin, Concept):
 class Relationship(AttributeMixin, Concept):
     """Abstract base class for ArchiMate relationship types.
 
-    A Relationship is a directed connection from a ``source`` Concept to a
-    ``target`` Concept.  Every concrete relationship subclass must define
-    ``category`` as a class variable.
+    A Relationship is a directed connection from a source Concept to a target
+    Concept, identified by :attr:`source_id` and :attr:`target_id` (ADR-051).
+    Endpoints are stored by ID -- not by object reference -- so that editing an
+    endpoint (rename, attribute change) leaves relationships untouched: the
+    model registry resolves the unchanged ID to the new instance.  Resolve an
+    endpoint to its concept via the owning model, e.g. ``model[rel.source_id]``.
 
-    Direct instantiation raises :class:`TypeError`.  Concrete relationship
-    types are defined in EPIC-005.
+    For ergonomics, the constructor also accepts ``source=`` / ``target=`` as a
+    :class:`Concept` (or a bare ID string); both are coerced to the stored
+    ``source_id`` / ``target_id``.
 
-    Reference: ArchiMate 3.2 Specification, Section 3.1.
+    Every concrete relationship subclass must define ``category`` as a class
+    variable.  Direct instantiation raises :class:`TypeError`.
+
+    Reference: ArchiMate 3.2 Specification, Section 3.1; ADR-051.
     """
 
     name: str = ""
-    source: Concept
-    target: Concept
+    source_id: str
+    target_id: str
     is_derived: bool = False
     category: ClassVar[RelationshipCategory]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_endpoints(cls, data: Any) -> Any:  # noqa: ANN401 — raw pre-validation input
+        """Accept ``source``/``target`` (Concept or ID) as ``source_id``/``target_id``."""
+        if isinstance(data, dict):
+            data = dict(data)
+            for field_name in ("source", "target"):
+                if field_name in data and f"{field_name}_id" not in data:
+                    value = data.pop(field_name)
+                    data[f"{field_name}_id"] = value.id if isinstance(value, Concept) else value
+        return data
 
 
 class RelationshipConnector(Concept):

--- a/src/etcion/metamodel/elements.py
+++ b/src/etcion/metamodel/elements.py
@@ -66,7 +66,7 @@ class Function(InternalBehaviorElement): ...
 
 
 class Interaction(InternalBehaviorElement):
-    assigned_elements: list[ActiveStructureElement] = Field(default_factory=list)
+    assigned_elements: tuple[ActiveStructureElement, ...] = Field(default_factory=tuple)
 
     @model_validator(mode="after")
     def _validate_assigned_elements(self) -> Interaction:
@@ -97,7 +97,7 @@ class CompositeElement(Element): ...
 class Grouping(CompositeElement):
     layer: ClassVar[Layer] = Layer.IMPLEMENTATION_MIGRATION
     aspect: ClassVar[Aspect] = Aspect.COMPOSITE
-    members: list[Concept] = Field(default_factory=list)
+    members: tuple[Concept, ...] = Field(default_factory=tuple)
 
     @property
     def _type_name(self) -> str:

--- a/src/etcion/metamodel/implementation_migration.py
+++ b/src/etcion/metamodel/implementation_migration.py
@@ -75,7 +75,7 @@ class Plateau(CompositeElement):
         badge_letter="I",
     )
 
-    members: list[Concept] = Field(default_factory=list)
+    members: tuple[Concept, ...] = Field(default_factory=tuple)
 
     @property
     def _type_name(self) -> str:

--- a/src/etcion/metamodel/model.py
+++ b/src/etcion/metamodel/model.py
@@ -281,6 +281,84 @@ class Model:
             if r.source_id == concept.id and (tgt := self._concepts.get(r.target_id)) is not None
         ]
 
+    def _shallow_clone(self) -> Model:
+        """Return a new model sharing this model's concepts and config by reference.
+
+        The registry dict is *shallow*-copied (cheap pointer copies); the immutable
+        concept instances themselves are shared (ADR-051).  Profiles, the
+        specialization registry, and custom rules are carried over.  The graph
+        cache is left empty so it recomputes against the (possibly edited)
+        registry.  Views are not carried over: a :class:`View` binds to a specific
+        model instance, so views must be rebuilt against the new model if needed.
+        """
+        new = Model()
+        new._concepts = dict(self._concepts)
+        new._profiles = list(self._profiles)
+        new._specialization_registry = dict(self._specialization_registry)
+        new._custom_rules = list(self._custom_rules)
+        return new
+
+    def with_added(self, concept: Concept) -> Model:
+        """Return a new model with *concept* added, sharing all existing concepts.
+
+        The original model is left unchanged (ADR-051 structural sharing): the new
+        model shares every existing concept instance by reference and adds *concept*.
+
+        :param concept: The concept to add.
+        :raises TypeError: if *concept* is not a :class:`Concept` instance.
+        :raises ValueError: if a concept with the same ``id`` already exists.
+        :returns: A new :class:`Model` instance.
+        """
+        if not isinstance(concept, Concept):
+            raise TypeError(f"Expected an instance of Concept, got {type(concept).__name__}")
+        if concept.id in self._concepts:
+            raise ValueError(f"Duplicate concept ID: '{concept.id}'")
+        new = self._shallow_clone()
+        new._concepts[concept.id] = concept
+        return new
+
+    def with_replaced(self, concept: Concept) -> Model:
+        """Return a new model with the concept of the same ``id`` replaced by *concept*.
+
+        This is the cheap-edit primitive (ADR-051): produce an edited instance with
+        ``concept.model_copy(update={...})`` and pass it here.  Because relationship
+        endpoints are addressed by ID, relationships referencing this concept need no
+        re-linking — they resolve the unchanged ID to the new instance.  ``O(1)`` plus
+        a shallow registry copy.
+
+        :param concept: The replacement concept; its ``id`` must already exist.
+        :raises TypeError: if *concept* is not a :class:`Concept` instance.
+        :raises KeyError: if no concept with that ``id`` exists in the model.
+        :returns: A new :class:`Model` instance.
+        """
+        if not isinstance(concept, Concept):
+            raise TypeError(f"Expected an instance of Concept, got {type(concept).__name__}")
+        if concept.id not in self._concepts:
+            raise KeyError(concept.id)
+        new = self._shallow_clone()
+        new._concepts[concept.id] = concept
+        return new
+
+    def with_removed(self, concept_or_id: Concept | str) -> Model:
+        """Return a new model without the given concept and any dangling relationships.
+
+        Relationships left with a missing source or target endpoint are dropped
+        (they would be broken).  All other concepts are shared by reference.
+
+        :param concept_or_id: The concept to remove, or its ``id``.
+        :raises KeyError: if no concept with that ``id`` exists in the model.
+        :returns: A new :class:`Model` instance.
+        """
+        cid = concept_or_id.id if isinstance(concept_or_id, Concept) else concept_or_id
+        if cid not in self._concepts:
+            raise KeyError(cid)
+        new = self._shallow_clone()
+        del new._concepts[cid]
+        for rid, concept in list(new._concepts.items()):
+            if isinstance(concept, Relationship) and cid in (concept.source_id, concept.target_id):
+                del new._concepts[rid]
+        return new
+
     def validate(self, *, strict: bool = False) -> list[ValidationError]:
         """Run all model-level validation rules.
 

--- a/src/etcion/metamodel/model.py
+++ b/src/etcion/metamodel/model.py
@@ -248,8 +248,8 @@ class Model:
         # Add edges: one directed edge per Relationship.
         for rel in self.relationships:
             g.add_edge(  # type: ignore[attr-defined]
-                rel.source.id,
-                rel.target.id,
+                rel.source_id,
+                rel.target_id,
                 type=type(rel),
                 name=getattr(rel, "name", None),
                 rel_id=rel.id,
@@ -260,16 +260,26 @@ class Model:
         return g
 
     def connected_to(self, concept: Concept) -> list[Relationship]:
-        """Return all relationships where *concept* is source or target (identity check)."""
-        return [r for r in self.relationships if r.source is concept or r.target is concept]
+        """Return all relationships where *concept* is source or target (by ID)."""
+        return [
+            r for r in self.relationships if r.source_id == concept.id or r.target_id == concept.id
+        ]
 
     def sources_of(self, concept: Concept) -> list[Concept]:
         """Return source concepts of all relationships targeting *concept*."""
-        return [r.source for r in self.relationships if r.target is concept]
+        return [
+            src
+            for r in self.relationships
+            if r.target_id == concept.id and (src := self._concepts.get(r.source_id)) is not None
+        ]
 
     def targets_of(self, concept: Concept) -> list[Concept]:
         """Return target concepts of all relationships sourced from *concept*."""
-        return [r.target for r in self.relationships if r.source is concept]
+        return [
+            tgt
+            for r in self.relationships
+            if r.source_id == concept.id and (tgt := self._concepts.get(r.target_id)) is not None
+        ]
 
     def validate(self, *, strict: bool = False) -> list[ValidationError]:
         """Run all model-level validation rules.
@@ -289,18 +299,23 @@ class Model:
         # Standard permission checks (skip Junction-connected relationships).
         junction_rels: dict[str, list[Relationship]] = {}
         for rel in self.relationships:
-            src_is_junc = isinstance(rel.source, RelationshipConnector)
-            tgt_is_junc = isinstance(rel.target, RelationshipConnector)
+            src = self._concepts.get(rel.source_id)
+            tgt = self._concepts.get(rel.target_id)
+            src_is_junc = isinstance(src, RelationshipConnector)
+            tgt_is_junc = isinstance(tgt, RelationshipConnector)
             # Track Junction adjacency for later validation.
             if src_is_junc:
-                junction_rels.setdefault(rel.source.id, []).append(rel)
+                junction_rels.setdefault(rel.source_id, []).append(rel)
             if tgt_is_junc:
-                junction_rels.setdefault(rel.target.id, []).append(rel)
+                junction_rels.setdefault(rel.target_id, []).append(rel)
             # Skip standard permission check for Junction-connected rels.
             if src_is_junc or tgt_is_junc:
                 continue
-            source_type = type(rel.source)
-            target_type = type(rel.target)
+            # Endpoints missing from the model cannot be permission-checked.
+            if src is None or tgt is None:
+                continue
+            source_type = type(src)
+            target_type = type(tgt)
             if not is_permitted(type(rel), source_type, target_type):  # type: ignore[arg-type]
                 err = ValidationError(
                     f"Relationship '{rel.id}' ({type(rel).__name__}: "
@@ -328,18 +343,20 @@ class Model:
             sources: list[type] = []
             targets: list[type] = []
             for r in rels:
-                if isinstance(r.source, RelationshipConnector):
+                r_src = self._concepts.get(r.source_id)
+                r_tgt = self._concepts.get(r.target_id)
+                if isinstance(r_src, RelationshipConnector):
                     # Junction is source -> r.target is the real target endpoint
-                    targets.append(type(r.target))
+                    targets.append(type(r_tgt))
                 else:
                     # Junction is target -> r.source is the real source endpoint
-                    sources.append(type(r.source))
-            for src in sources:
-                for tgt in targets:
-                    if not is_permitted(rel_type, src, tgt):
+                    sources.append(type(r_src))
+            for src_type in sources:
+                for tgt_type in targets:
+                    if not is_permitted(rel_type, src_type, tgt_type):
                         err = ValidationError(
                             f"Junction '{jid}': {rel_type.__name__} from "
-                            f"{src.__name__} to {tgt.__name__} is not permitted"
+                            f"{src_type.__name__} to {tgt_type.__name__} is not permitted"
                         )
                         if strict:
                             raise err

--- a/src/etcion/metamodel/technology.py
+++ b/src/etcion/metamodel/technology.py
@@ -72,7 +72,7 @@ class SystemSoftware(Node):
 
 
 class TechnologyCollaboration(TechnologyInternalActiveStructureElement):
-    assigned_elements: list[ActiveStructureElement] = Field(default_factory=list)
+    assigned_elements: tuple[ActiveStructureElement, ...] = Field(default_factory=tuple)
     notation: ClassVar[NotationMetadata] = NotationMetadata(
         corner_shape="square",
         layer_color="#C9E7B7",

--- a/src/etcion/metamodel/viewpoints.py
+++ b/src/etcion/metamodel/viewpoints.py
@@ -102,14 +102,13 @@ class View(BaseModel):
                 # Relationship type must itself be permitted.
                 if not any(issubclass(type(concept), t) for t in permitted):
                     continue
-                new_src = id_map.get(concept.source.id)
-                new_tgt = id_map.get(concept.target.id)
+                new_src = id_map.get(concept.source_id)
+                new_tgt = id_map.get(concept.target_id)
                 if new_src is None or new_tgt is None:
                     # One or both endpoints were excluded — drop this relationship.
                     continue
-                copied_rels.append(
-                    concept.model_copy(deep=True, update={"source": new_src, "target": new_tgt})
-                )
+                # Endpoints are addressed by ID (ADR-051); the copy preserves them.
+                copied_rels.append(concept.model_copy(deep=True))
 
         # Phase 3: assemble the result model.
         result = _Model()

--- a/src/etcion/patterns.py
+++ b/src/etcion/patterns.py
@@ -21,6 +21,7 @@ Reference: GitHub Issues #2, #3, ADR-041.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Protocol
 
@@ -92,7 +93,7 @@ class AttrPredicate:
         """
         # Resolve the attribute value: extended_attributes first, then direct field.
         ext = getattr(concept, "extended_attributes", {})
-        if isinstance(ext, dict) and self.attr_name in ext:
+        if isinstance(ext, Mapping) and self.attr_name in ext:
             actual = ext[self.attr_name]
         else:
             actual = getattr(concept, self.attr_name, None)

--- a/src/etcion/patterns.py
+++ b/src/etcion/patterns.py
@@ -826,9 +826,9 @@ class Pattern:
             for rel in connected:
                 if not isinstance(rel, cc.rel_type):
                     continue
-                if cc.direction == "incoming" and rel.target is concept:
+                if cc.direction == "incoming" and rel.target_id == concept.id:
                     count += 1
-                elif cc.direction == "outgoing" and rel.source is concept:
+                elif cc.direction == "outgoing" and rel.source_id == concept.id:
                     count += 1
                 elif cc.direction == "any":
                     count += 1
@@ -997,7 +997,9 @@ class Pattern:
                 # Anchor is source — look for outgoing edges to the target type.
                 other_type = self._nodes[tgt_alias]
                 has_match = any(
-                    isinstance(r, rel_type) and isinstance(r.target, other_type) for r in connected
+                    isinstance(r, rel_type)
+                    and isinstance(model._concepts.get(r.target_id), other_type)
+                    for r in connected
                 )
                 if not has_match:
                     missing.append(f"No {rel_type.__name__} edge to any {other_type.__name__}")
@@ -1005,7 +1007,9 @@ class Pattern:
                 # Anchor is target — look for incoming edges from the source type.
                 other_type = self._nodes[src_alias]
                 has_match = any(
-                    isinstance(r, rel_type) and isinstance(r.source, other_type) for r in connected
+                    isinstance(r, rel_type)
+                    and isinstance(model._concepts.get(r.source_id), other_type)
+                    for r in connected
                 )
                 if not has_match:
                     missing.append(f"No {rel_type.__name__} edge from any {other_type.__name__}")
@@ -1017,9 +1021,9 @@ class Pattern:
             for rel in connected:
                 if not isinstance(rel, cc.rel_type):
                     continue
-                if cc.direction == "incoming" and rel.target is elem:
+                if cc.direction == "incoming" and rel.target_id == elem.id:
                     count += 1
-                elif cc.direction == "outgoing" and rel.source is elem:
+                elif cc.direction == "outgoing" and rel.source_id == elem.id:
                     count += 1
                 elif cc.direction == "any":
                     count += 1

--- a/src/etcion/serialization/csv.py
+++ b/src/etcion/serialization/csv.py
@@ -235,7 +235,7 @@ def from_csv(
                         # Blank cell for a required str field (typically `name`):
                         # pass "" so writer/reader are symmetric (issue #102).
                         kwargs[key] = ""
-                rel = cls(source=id_map[source_id], target=id_map[target_id], **kwargs)
+                rel = cls(source_id=source_id, target_id=target_id, **kwargs)
                 model.add(rel)
 
     return model
@@ -288,8 +288,8 @@ def to_csv(
                 writer.writerow(
                     [
                         type(rel).__name__,
-                        rel.source.id,
-                        rel.target.id,
+                        rel.source_id,
+                        rel.target_id,
                         getattr(rel, "name", "") or "",
                     ]
                 )

--- a/src/etcion/serialization/dataframe.py
+++ b/src/etcion/serialization/dataframe.py
@@ -115,8 +115,8 @@ def to_dataframe(model: Model) -> tuple[Any, Any]:
         rel_rows.append(
             {
                 "type": type(rel).__name__,
-                "source": rel.source.id,
-                "target": rel.target.id,
+                "source": rel.source_id,
+                "target": rel.target_id,
                 "name": rel.name or "",
             }
         )
@@ -244,23 +244,23 @@ def to_flat_dataframe(model: Model) -> Any:  # noqa: ANN401
     connected_ids: set[str] = set()
 
     for rel in model.relationships:
-        src = rel.source
-        tgt = rel.target
-        connected_ids.add(src.id)
-        connected_ids.add(tgt.id)
-        src_layer = getattr(type(src), "layer", None)
-        tgt_layer = getattr(type(tgt), "layer", None)
+        src = model._concepts.get(rel.source_id)
+        tgt = model._concepts.get(rel.target_id)
+        connected_ids.add(rel.source_id)
+        connected_ids.add(rel.target_id)
+        src_layer = getattr(type(src), "layer", None) if src is not None else None
+        tgt_layer = getattr(type(tgt), "layer", None) if tgt is not None else None
         rows.append(
             {
                 "rel_type": type(rel).__name__,
                 "rel_id": rel.id,
                 "rel_name": getattr(rel, "name", None) or None,
-                "source_id": src.id,
-                "source_type": type(src).__name__,
+                "source_id": rel.source_id,
+                "source_type": type(src).__name__ if src is not None else None,
                 "source_name": getattr(src, "name", None),
                 "source_layer": src_layer.value if src_layer is not None else None,
-                "target_id": tgt.id,
-                "target_type": type(tgt).__name__,
+                "target_id": rel.target_id,
+                "target_type": type(tgt).__name__ if tgt is not None else None,
                 "target_name": getattr(tgt, "name", None),
                 "target_layer": tgt_layer.value if tgt_layer is not None else None,
             }

--- a/src/etcion/serialization/json.py
+++ b/src/etcion/serialization/json.py
@@ -115,10 +115,10 @@ def _serialize_concept(concept: Concept) -> dict[str, Any]:
     data: dict[str, Any] = concept.model_dump(mode="json")
     data["_type"] = concept._type_name
     if isinstance(concept, Relationship):
-        # model_dump produces {"id": "<uuid>"} for nested Concept fields;
-        # replace with a plain ID string for portability.
-        data["source"] = concept.source.id
-        data["target"] = concept.target.id
+        # Endpoints are stored as source_id/target_id (ADR-051); emit them under
+        # the stable "source"/"target" wire keys (bare ID strings).
+        data["source"] = data.pop("source_id")
+        data["target"] = data.pop("target_id")
     return data
 
 
@@ -196,7 +196,6 @@ def model_from_dict(data: dict[str, Any]) -> Model:
         :data:`_NAME_TO_TYPE` or a relationship references an unknown element ID.
     """
     model = Model()
-    id_map: dict[str, Concept] = {}
 
     for prof_data in data.get("profiles", []):
         profile = _deserialize_profile(prof_data)
@@ -207,15 +206,16 @@ def model_from_dict(data: dict[str, Any]) -> Model:
         type_name = elem_data.pop("_type")
         cls = _NAME_TO_TYPE[type_name]
         elem = cls.model_validate(elem_data)
-        id_map[elem.id] = elem
         model.add(elem)
 
     for rel_data in data.get("relationships", []):
         rel_data = dict(rel_data)  # copy so we don't mutate the caller's dict
         type_name = rel_data.pop("_type")
         cls = _NAME_TO_TYPE[type_name]
-        rel_data["source"] = id_map[rel_data["source"]]
-        rel_data["target"] = id_map[rel_data["target"]]
+        # Endpoints are stored by ID (ADR-051); map the wire "source"/"target"
+        # keys to the source_id/target_id fields.
+        rel_data["source_id"] = rel_data.pop("source")
+        rel_data["target_id"] = rel_data.pop("target")
         rel = cls.model_validate(rel_data)
         model.add(rel)
 

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -156,8 +156,8 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
     desc = TYPE_REGISTRY[type(rel)]
     el = etree.Element(f"{{{ARCHIMATE_NS}}}relationship", nsmap=NSMAP)
     el.set("identifier", _to_exchange_id(rel.id))
-    el.set("source", _to_exchange_id(rel.source.id))
-    el.set("target", _to_exchange_id(rel.target.id))
+    el.set("source", _to_exchange_id(rel.source_id))
+    el.set("target", _to_exchange_id(rel.target_id))
     el.set(f"{{{XSI_NS}}}type", desc.xml_tag)
 
     if rel.name:
@@ -232,8 +232,8 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
         node_el.set("h", str(_node_h))
 
     for rel in view_relationships:
-        src_exchange_id = _to_exchange_id(rel.source.id)
-        tgt_exchange_id = _to_exchange_id(rel.target.id)
+        src_exchange_id = _to_exchange_id(rel.source_id)
+        tgt_exchange_id = _to_exchange_id(rel.target_id)
         src_node_id = elem_exchange_id_to_node_id.get(src_exchange_id)
         tgt_node_id = elem_exchange_id_to_node_id.get(tgt_exchange_id)
         # Skip connections whose endpoints have no node in this view.

--- a/test/derivation/test_engine.py
+++ b/test/derivation/test_engine.py
@@ -144,8 +144,8 @@ class TestCrossLayerRealizationChain:
         assert len(derived) == 1
         d = derived[0]
         assert isinstance(d, Realization)
-        assert d.source is art
-        assert d.target is bo
+        assert d.source_id == art.id
+        assert d.target_id == bo.id
         assert d.is_derived is True
 
     def test_tech_app_business_process_chain(self) -> None:
@@ -164,8 +164,8 @@ class TestCrossLayerRealizationChain:
         assert len(derived) == 1
         d = derived[0]
         assert isinstance(d, Realization)
-        assert d.source is tp
-        assert d.target is bp
+        assert d.source_id == tp.id
+        assert d.target_id == bp.id
         assert d.is_derived is True
 
 

--- a/test/e2e/test_analytical_workflows.py
+++ b/test/e2e/test_analytical_workflows.py
@@ -370,7 +370,8 @@ class TestModelDiffKnownChanges:
         # Rename the first ApplicationComponent in the mutated copy
         target_app = next(iter(model.elements_of_type(ApplicationComponent)))
         original_name = target_app.name
-        target_app.name = "Renamed Application XYZZY"
+        target_app = target_app.model_copy(update={"name": "Renamed Application XYZZY"})
+        model._concepts[target_app.id] = target_app
 
         diff = diff_models(baseline, model)
         modified_ids = {cc.concept_id for cc in diff.modified}
@@ -385,7 +386,8 @@ class TestModelDiffKnownChanges:
         baseline = copy.deepcopy(model)
 
         target_app = next(iter(model.elements_of_type(ApplicationComponent)))
-        target_app.name = "Renamed Application XYZZY"
+        target_app = target_app.model_copy(update={"name": "Renamed Application XYZZY"})
+        model._concepts[target_app.id] = target_app
 
         diff = diff_models(baseline, model)
         change = next((cc for cc in diff.modified if cc.concept_id == target_app.id), None)
@@ -485,11 +487,12 @@ class TestModelMergeConflictDetection:
 
         # Find the shared element in both copies by the same ID
         shared_app_id = next(iter(model.elements_of_type(ApplicationComponent))).id
-        app_in_a = branch_a._concepts[shared_app_id]
-        app_in_b = branch_b._concepts[shared_app_id]
-
-        app_in_a.name = "Branch A Name"
-        app_in_b.name = "Branch B Name"
+        branch_a._concepts[shared_app_id] = branch_a._concepts[shared_app_id].model_copy(
+            update={"name": "Branch A Name"}
+        )
+        branch_b._concepts[shared_app_id] = branch_b._concepts[shared_app_id].model_copy(
+            update={"name": "Branch B Name"}
+        )
 
         # Each branch adds a unique element (non-conflicting)
         branch_a.add(ApplicationComponent(name="Branch A Exclusive App"))

--- a/test/e2e/test_analytical_workflows.py
+++ b/test/e2e/test_analytical_workflows.py
@@ -101,14 +101,15 @@ class TestPatternMatchingPawsPlus:
         orphaned_leaf_caps: list[str] = []
         for cap in model.elements_of_type(Capability):
             apps = [
-                r.source
+                model[r.source_id]
                 for r in model.connected_to(cap)
-                if isinstance(r, Realization) and isinstance(r.source, ApplicationComponent)
+                if isinstance(r, Realization)
+                and isinstance(model[r.source_id], ApplicationComponent)
             ]
             children = [
                 r
                 for r in model.relationships_of_type(Composition)
-                if r.source is cap and isinstance(r.target, Capability)
+                if r.source_id == cap.id and isinstance(model[r.target_id], Capability)
             ]
             if not apps and not children:
                 orphaned_leaf_caps.append(cap.name)
@@ -129,10 +130,10 @@ class TestPatternMatchingPawsPlus:
 
         svc_count: Counter[str] = Counter()
         for rel in model.relationships_of_type(Serving):
-            if isinstance(rel.source, ApplicationService) and isinstance(
-                rel.target, ApplicationComponent
+            if isinstance(model[rel.source_id], ApplicationService) and isinstance(
+                model[rel.target_id], ApplicationComponent
             ):
-                svc_count[rel.source.name] += 1
+                svc_count[model[rel.source_id].name] += 1
 
         high_fanout = {name: count for name, count in svc_count.items() if count >= 2}
         assert "Process Payment" in high_fanout, (
@@ -148,10 +149,10 @@ class TestPatternMatchingPawsPlus:
 
         svc_count: Counter[str] = Counter()
         for rel in model.relationships_of_type(Serving):
-            if isinstance(rel.source, ApplicationService) and isinstance(
-                rel.target, ApplicationComponent
+            if isinstance(model[rel.source_id], ApplicationService) and isinstance(
+                model[rel.target_id], ApplicationComponent
             ):
-                svc_count[rel.source.name] += 1
+                svc_count[model[rel.source_id].name] += 1
 
         high_fanout_names = [name for name, count in svc_count.items() if count >= 2]
         assert len(high_fanout_names) == 1, (
@@ -170,11 +171,11 @@ class TestPatternMatchingPawsPlus:
         contested: list[str] = []
         for data in model.elements_of_type(DataObject):
             writers = [
-                r.source
+                model[r.source_id]
                 for r in model.connected_to(data)
                 if isinstance(r, Access)
                 and r.access_mode == AccessMode.WRITE
-                and isinstance(r.source, ApplicationComponent)
+                and isinstance(model[r.source_id], ApplicationComponent)
             ]
             if len(writers) > 1:
                 contested.append(data.name)

--- a/test/e2e/test_model_lifecycle.py
+++ b/test/e2e/test_model_lifecycle.py
@@ -75,8 +75,10 @@ def _build_lifecycle_model() -> tuple[Model, Profile, Viewpoint, View]:
     """
     model = Model()
 
-    processor = ApplicationComponent(name="Payment Processor")
-    gateway = ApplicationService(name="Payment Gateway")
+    processor = ApplicationComponent(
+        name="Payment Processor", extended_attributes={"risk_score": 0.75}
+    )
+    gateway = ApplicationService(name="Payment Gateway", specialization="primary")
     model.add(processor)
     model.add(gateway)
     # Assignment from ApplicationComponent -> ApplicationService is permitted
@@ -90,10 +92,6 @@ def _build_lifecycle_model() -> tuple[Model, Profile, Viewpoint, View]:
         attribute_extensions={ApplicationComponent: {"risk_score": float}},
     )
     model.apply_profile(profile)
-
-    # Customize elements via the profile
-    gateway.specialization = "primary"
-    processor.extended_attributes["risk_score"] = 0.75
 
     vp = Viewpoint(
         name="Application Usage",
@@ -449,7 +447,9 @@ class TestJsonRoundTrip:
         as ``int`` (not silently promoted to float as happens in XML).
         """
         model = Model()
-        component = ApplicationComponent(name="Auth Service")
+        component = ApplicationComponent(
+            name="Auth Service", extended_attributes={"replica_count": 3}
+        )
         model.add(component)
 
         profile = Profile(
@@ -457,7 +457,6 @@ class TestJsonRoundTrip:
             attribute_extensions={ApplicationComponent: {"replica_count": int}},
         )
         model.apply_profile(profile)
-        component.extended_attributes["replica_count"] = 3
 
         data = model_to_dict(model)
         recovered = model_from_dict(data)

--- a/test/e2e/test_model_lifecycle.py
+++ b/test/e2e/test_model_lifecycle.py
@@ -245,12 +245,12 @@ class TestXmlRoundTrip:
     def test_relationship_source_target_preserved(self) -> None:
         """Relationship source and target IDs survive an XML round-trip."""
         model, _, _, _ = _build_lifecycle_model()
-        original_rels = {(r.source.id, r.target.id) for r in model.relationships}
+        original_rels = {(r.source_id, r.target_id) for r in model.relationships}
 
         tree = serialize_model(model)
         recovered = deserialize_model(tree)
 
-        recovered_rels = {(r.source.id, r.target.id) for r in recovered.relationships}
+        recovered_rels = {(r.source_id, r.target_id) for r in recovered.relationships}
         assert recovered_rels == original_rels
 
     def test_specialization_survives_xml_round_trip(self) -> None:
@@ -396,8 +396,8 @@ class TestJsonRoundTrip:
         data = model_to_dict(model)
         recovered = model_from_dict(data)
 
-        original_rels = {(r.source.id, r.target.id) for r in model.relationships}
-        recovered_rels = {(r.source.id, r.target.id) for r in recovered.relationships}
+        original_rels = {(r.source_id, r.target_id) for r in model.relationships}
+        recovered_rels = {(r.source_id, r.target_id) for r in recovered.relationships}
         assert recovered_rels == original_rels
 
     def test_specialization_survives_json_round_trip(self) -> None:

--- a/test/e2e/test_petco_model.py
+++ b/test/e2e/test_petco_model.py
@@ -90,22 +90,22 @@ class TestRelationshipIntegrity:
         model, _ = petco_model
         element_ids = self._element_ids(model)
         for rel in model.relationships_of_type(Realization):
-            assert rel.source.id in element_ids, (
-                f"Realization '{rel.id}' source '{rel.source.id}' not in model.elements"
+            assert rel.source_id in element_ids, (
+                f"Realization '{rel.id}' source '{rel.source_id}' not in model.elements"
             )
-            assert rel.target.id in element_ids, (
-                f"Realization '{rel.id}' target '{rel.target.id}' not in model.elements"
+            assert rel.target_id in element_ids, (
+                f"Realization '{rel.id}' target '{rel.target_id}' not in model.elements"
             )
 
     def test_servings_have_valid_endpoints(self, petco_model):
         model, _ = petco_model
         element_ids = self._element_ids(model)
         for rel in model.relationships_of_type(Serving):
-            assert rel.source.id in element_ids, (
-                f"Serving '{rel.id}' source '{rel.source.id}' not in model.elements"
+            assert rel.source_id in element_ids, (
+                f"Serving '{rel.id}' source '{rel.source_id}' not in model.elements"
             )
-            assert rel.target.id in element_ids, (
-                f"Serving '{rel.id}' target '{rel.target.id}' not in model.elements"
+            assert rel.target_id in element_ids, (
+                f"Serving '{rel.id}' target '{rel.target_id}' not in model.elements"
             )
 
     def test_no_dangling_references(self, petco_model):
@@ -115,7 +115,7 @@ class TestRelationshipIntegrity:
         dangling = [
             rel
             for rel in model.relationships
-            if rel.source.id not in element_ids or rel.target.id not in element_ids
+            if rel.source_id not in element_ids or rel.target_id not in element_ids
         ]
         assert dangling == [], (
             f"Found {len(dangling)} relationship(s) with dangling endpoint(s): "
@@ -229,15 +229,16 @@ class TestCapabilityHierarchyIntegrity:
         return [
             r
             for r in model.relationships_of_type(Composition)
-            if isinstance(r.source, Capability) and isinstance(r.target, Capability)
+            if isinstance(model[r.source_id], Capability)
+            and isinstance(model[r.target_id], Capability)
         ]
 
     def test_l0_capabilities_have_at_least_one_child(self, petco_model):
         """Every L0 capability (not a Composition target) must compose at least one child."""
         model, _ = petco_model
         comp_rels = self._capability_composition_rels(model)
-        comp_targets = {r.target.id for r in comp_rels}
-        comp_sources = {r.source.id for r in comp_rels}
+        comp_targets = {r.target_id for r in comp_rels}
+        comp_sources = {r.source_id for r in comp_rels}
 
         caps = model.elements_of_type(Capability)
         l0_caps = [c for c in caps if c.id not in comp_targets]
@@ -252,7 +253,7 @@ class TestCapabilityHierarchyIntegrity:
         """Every non-L0 Capability must be a Composition target."""
         model, _ = petco_model
         comp_rels = self._capability_composition_rels(model)
-        comp_targets = {r.target.id for r in comp_rels}
+        comp_targets = {r.target_id for r in comp_rels}
 
         caps = model.elements_of_type(Capability)
         l0_caps_ids = {c.id for c in caps if c.id not in comp_targets}
@@ -277,7 +278,7 @@ class TestCapabilityHierarchyIntegrity:
         # Build adjacency list (source -> set of targets)
         adj: dict[str, set[str]] = {}
         for r in comp_rels:
-            adj.setdefault(r.source.id, set()).add(r.target.id)
+            adj.setdefault(r.source_id, set()).add(r.target_id)
 
         caps = model.elements_of_type(Capability)
         visited: set[str] = set()
@@ -328,8 +329,8 @@ class TestDataGovernanceCompleteness:
         # Map DataObject ID -> list of WRITE Access relationships
         do_write_access: dict[str, list] = {}
         for rel in model.relationships_of_type(Access):
-            if rel.access_mode == AccessMode.WRITE and isinstance(rel.target, DataObject):
-                do_write_access.setdefault(rel.target.id, []).append(rel)
+            if rel.access_mode == AccessMode.WRITE and isinstance(model[rel.target_id], DataObject):
+                do_write_access.setdefault(rel.target_id, []).append(rel)
 
         missing_sor = [do for do in dos if do.id not in do_write_access]
         assert not missing_sor, f"DataObjects without a system of record (WRITE Access): " + str(

--- a/test/e2e/test_serialization_matrix.py
+++ b/test/e2e/test_serialization_matrix.py
@@ -55,8 +55,8 @@ def profiled_model() -> Model:
     """
     model = Model()
 
-    svc = ApplicationService(name="Payment Gateway")
-    app = ApplicationComponent(name="Payment Processor")
+    svc = ApplicationService(name="Payment Gateway", specialization="primary")
+    app = ApplicationComponent(name="Payment Processor", extended_attributes={"risk_score": 0.85})
     model.add(svc)
     model.add(app)
     model.add(Serving(name="", source=app, target=svc))
@@ -67,9 +67,6 @@ def profiled_model() -> Model:
         attribute_extensions={ApplicationComponent: {"risk_score": float}},
     )
     model.apply_profile(profile)
-
-    svc.specialization = "primary"
-    app.extended_attributes["risk_score"] = 0.85
 
     return model
 

--- a/test/e2e/test_user_journeys.py
+++ b/test/e2e/test_user_journeys.py
@@ -398,11 +398,11 @@ def test_data_governance_audit_confidential(
     for rel in model.relationships:
         if (
             isinstance(rel, Access)
-            and isinstance(rel.source, ApplicationComponent)
-            and isinstance(rel.target, DataObject)
+            and isinstance(model[rel.source_id], ApplicationComponent)
+            and isinstance(model[rel.target_id], DataObject)
             and rel.access_mode == AccessMode.READ
         ):
-            read_sources.setdefault(rel.target.id, []).append(rel.source)
+            read_sources.setdefault(rel.target_id, []).append(model[rel.source_id])
 
     high_access_objects: list[DataObject] = [
         m["obj"]  # type: ignore[assignment]

--- a/test/metamodel/test_concepts.py
+++ b/test/metamodel/test_concepts.py
@@ -197,8 +197,8 @@ class TestRelationship:
         src = ConcreteElement_2(name="src")
         tgt = ConcreteElement_2(name="tgt")
         rel = ConcreteRelationship(name="R", source=src, target=tgt)
-        assert rel.source is src
-        assert rel.target is tgt
+        assert rel.source_id == src.id
+        assert rel.target_id == tgt.id
 
     def test_is_derived_defaults_to_false(self) -> None:
         """ConcreteRelationship(...).is_derived is False."""

--- a/test/metamodel/test_elements.py
+++ b/test/metamodel/test_elements.py
@@ -203,9 +203,9 @@ class TestGroupingInstantiation:
         g = Grouping(name="g")
         assert g.name == "g"
 
-    def test_members_defaults_to_empty_list(self) -> None:
+    def test_members_defaults_to_empty(self) -> None:
         g = Grouping(name="g")
-        assert g.members == []
+        assert g.members == ()
 
     def test_type_name(self) -> None:
         g = Grouping(name="g")

--- a/test/metamodel/test_implementation_migration.py
+++ b/test/metamodel/test_implementation_migration.py
@@ -183,7 +183,7 @@ class TestNotation_2:
 class TestMembers:
     def test_members_defaults_to_empty(self) -> None:
         p = Plateau(name="x")
-        assert p.members == []
+        assert p.members == ()
 
     def test_accepts_core_element_as_member(self) -> None:
         wp = WorkPackage(name="Build phase 1")
@@ -197,11 +197,13 @@ class TestMembers:
         p = Plateau(name="x", members=[wp1, wp2])
         assert len(p.members) == 2
 
-    def test_members_list_is_independent_per_instance(self) -> None:
+    def test_members_is_immutable(self) -> None:
+        # members is an immutable tuple (ADR-051), so the shared-mutable-default
+        # hazard cannot occur and in-place mutation is rejected.
         p1 = Plateau(name="a")
-        p2 = Plateau(name="b")
-        p1.members.append(WorkPackage(name="wp"))
-        assert len(p2.members) == 0
+        assert isinstance(p1.members, tuple)
+        with pytest.raises(AttributeError):
+            p1.members.append(WorkPackage(name="wp"))  # type: ignore[attr-defined]
 
 
 @pytest.fixture()

--- a/test/metamodel/test_model.py
+++ b/test/metamodel/test_model.py
@@ -741,8 +741,8 @@ class TestCompositionPatterns:
         result = [
             r
             for r in full_model.relationships_of_type(Serving)
-            if isinstance(r.source, ApplicationComponent)
-            and isinstance(r.target, ApplicationService)
+            if isinstance(full_model[r.source_id], ApplicationComponent)
+            and isinstance(full_model[r.target_id], ApplicationService)
         ]
         assert len(result) == 1
         assert result[0].name == "serve-1"

--- a/test/metamodel/test_model_editing.py
+++ b/test/metamodel/test_model_editing.py
@@ -1,0 +1,127 @@
+"""Structural-sharing editing API on Model (ADR-051).
+
+``with_added`` / ``with_replaced`` / ``with_removed`` return new immutable
+models that share unchanged concept instances with the source model.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from etcion.metamodel.business import BusinessActor, BusinessProcess
+from etcion.metamodel.model import Model
+from etcion.metamodel.relationships import Assignment
+
+
+def _model() -> tuple[Model, BusinessActor, BusinessProcess, Assignment]:
+    a = BusinessActor(id="a1", name="A")
+    b = BusinessProcess(id="b1", name="B")
+    rel = Assignment(id="rel-ab", name="AB", source=a, target=b)
+    return Model(concepts=[a, b, rel]), a, b, rel
+
+
+class TestWithReplaced:
+    def test_returns_new_model_with_edited_concept(self) -> None:
+        model, a, _b, _rel = _model()
+        renamed = a.model_copy(update={"name": "A2"})
+
+        edited = model.with_replaced(renamed)
+
+        assert edited is not model
+        assert edited["a1"].name == "A2"
+
+    def test_original_is_unchanged(self) -> None:
+        model, a, _b, _rel = _model()
+        model.with_replaced(a.model_copy(update={"name": "A2"}))
+        assert model["a1"].name == "A"
+
+    def test_untouched_concepts_are_shared(self) -> None:
+        model, a, b, rel = _model()
+        edited = model.with_replaced(a.model_copy(update={"name": "A2"}))
+        # b and rel are shared by reference; only a1 differs.
+        assert edited["b1"] is b
+        assert edited["rel-ab"] is rel
+
+    def test_relationship_resolves_to_new_instance_without_relink(self) -> None:
+        model, a, _b, _rel = _model()
+        renamed = a.model_copy(update={"name": "A2"})
+        edited = model.with_replaced(renamed)
+        # The relationship still references "a1" by ID; it now resolves to the
+        # edited instance with no re-linking.
+        rel = edited["rel-ab"]
+        assert edited[rel.source_id] is renamed
+
+    def test_missing_id_raises(self) -> None:
+        model, _a, _b, _rel = _model()
+        ghost = BusinessActor(id="nope", name="X")
+        with pytest.raises(KeyError):
+            model.with_replaced(ghost)
+
+    def test_non_concept_raises(self) -> None:
+        model, _a, _b, _rel = _model()
+        with pytest.raises(TypeError):
+            model.with_replaced("not a concept")  # type: ignore[arg-type]
+
+
+class TestWithAdded:
+    def test_adds_concept(self) -> None:
+        model, _a, _b, _rel = _model()
+        c = BusinessActor(id="c1", name="C")
+        edited = model.with_added(c)
+        assert edited["c1"] is c
+        assert "c1" not in model._concepts
+
+    def test_shares_existing_concepts(self) -> None:
+        model, a, _b, _rel = _model()
+        edited = model.with_added(BusinessActor(id="c1", name="C"))
+        assert edited["a1"] is a
+
+    def test_duplicate_id_raises(self) -> None:
+        model, _a, _b, _rel = _model()
+        with pytest.raises(ValueError, match="Duplicate"):
+            model.with_added(BusinessActor(id="a1", name="dup"))
+
+
+class TestWithRemoved:
+    def test_removes_concept_and_dangling_relationships(self) -> None:
+        model, a, _b, _rel = _model()
+        edited = model.with_removed(a)
+        ids = {c.id for c in edited}
+        assert "a1" not in ids
+        assert "rel-ab" not in ids  # dangling (source removed) -> dropped
+        assert "b1" in ids
+
+    def test_accepts_id_string(self) -> None:
+        model, _a, _b, _rel = _model()
+        edited = model.with_removed("a1")
+        assert "a1" not in {c.id for c in edited}
+
+    def test_original_unchanged(self) -> None:
+        model, _a, _b, _rel = _model()
+        model.with_removed("a1")
+        assert "a1" in model._concepts
+        assert "rel-ab" in model._concepts
+
+    def test_keeps_unrelated_relationships(self) -> None:
+        a = BusinessActor(id="a1", name="A")
+        b = BusinessProcess(id="b1", name="B")
+        c = BusinessProcess(id="c1", name="C")
+        rel_bc = Assignment(id="rel-bc", name="BC", source=b, target=c)
+        model = Model(concepts=[a, b, c, rel_bc])
+
+        edited = model.with_removed("a1")
+        assert edited["rel-bc"] is rel_bc  # untouched relationship shared
+
+    def test_missing_id_raises(self) -> None:
+        model, _a, _b, _rel = _model()
+        with pytest.raises(KeyError):
+            model.with_removed("nope")
+
+
+def test_edited_model_recomputes_graph_against_new_registry() -> None:
+    pytest.importorskip("networkx")
+    model, a, _b, _rel = _model()
+    edited = model.with_removed(a)
+    # The edited model's graph must reflect the removal, not inherit a stale cache.
+    g = edited.to_networkx()
+    assert "a1" not in g.nodes

--- a/test/metamodel/test_relationships.py
+++ b/test/metamodel/test_relationships.py
@@ -85,8 +85,8 @@ class TestRelationshipCommon:
     def test_source_and_target(self, spec: RelSpec) -> None:
         a, b = StubActiveStructure(name="a"), StubActiveStructure(name="b")
         r = spec.cls(name="r", source=a, target=b)
-        assert r.source is a
-        assert r.target is b
+        assert r.source_id == a.id
+        assert r.target_id == b.id
 
     def test_category(self, spec: RelSpec) -> None:
         assert spec.cls.category is spec.category
@@ -369,8 +369,8 @@ class TestAssociation:
         a = StubActiveStructure(name="a")
         b = StubBehavior(name="b")
         r = Association(name="assoc", source=a, target=b)
-        assert r.source is a
-        assert r.target is b
+        assert r.source_id == a.id
+        assert r.target_id == b.id
 
     def test_accepts_relationship_as_target(self) -> None:
         """Association can target a Relationship (per spec, any two concepts)."""
@@ -386,7 +386,7 @@ class TestAssociation:
         b = StubActiveStructure(name="b")
         rel = _StubRel(name="r", source=a, target=b)
         assoc = Association(name="assoc", source=a, target=rel)
-        assert assoc.target is rel
+        assert assoc.target_id == rel.id
 
 
 # ---------------------------------------------------------------------------
@@ -770,4 +770,4 @@ class TestPassiveBehaviorModelValidate:
         bo = BusinessObject(name="obj")
         bp = BusinessProcess(name="proc")
         rel = Assignment(name="bad", source=bo, target=bp)  # no error here
-        assert rel.source is bo
+        assert rel.source_id == bo.id

--- a/test/serialization/test_csv.py
+++ b/test/serialization/test_csv.py
@@ -79,8 +79,8 @@ class TestFromCsv:
         assert len(model.relationships) == 1
         rel = model.relationships[0]
         assert type(rel).__name__ == "Serving"
-        assert rel.source.name == "Alice"
-        assert rel.target.name == "Order Handling"
+        assert model[rel.source_id].name == "Alice"
+        assert model[rel.target_id].name == "Order Handling"
 
     def test_optional_id_column(self, tmp_path: Path) -> None:
         """When an id column is present the element receives that exact ID."""

--- a/test/serialization/test_dataframe.py
+++ b/test/serialization/test_dataframe.py
@@ -87,8 +87,8 @@ class TestFromDataFrame:
         assert len(model.relationships) == 1
         rel = model.relationships[0]
         assert type(rel).__name__ == "Serving"
-        assert rel.source.name == "Alice"
-        assert rel.target.name == "Order Handling"
+        assert model[rel.source_id].name == "Alice"
+        assert model[rel.target_id].name == "Order Handling"
 
     def test_import_error(self) -> None:
         """When pandas is not available, from_dataframe raises ImportError with a clear message."""

--- a/test/serialization/test_json.py
+++ b/test/serialization/test_json.py
@@ -83,8 +83,8 @@ class TestModelFromDict:
         data = model_to_dict(simple_model)
         restored = model_from_dict(data)
         rel = restored.relationships[0]
-        assert isinstance(rel.source, BusinessActor)
-        assert isinstance(rel.target, BusinessProcess)
+        assert isinstance(restored[rel.source_id], BusinessActor)
+        assert isinstance(restored[rel.target_id], BusinessProcess)
 
     def test_round_trip_ids_preserved(self, simple_model):
         original_ids = {c.id for c in simple_model.concepts}

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -334,8 +334,8 @@ class TestRoundTrip:
         tree = serialize_model(round_trip_model)
         restored = deserialize_model(tree)
         rel = restored.relationships[0]
-        assert isinstance(rel.source, BusinessActor)
-        assert isinstance(rel.target, BusinessProcess)
+        assert isinstance(restored[rel.source_id], BusinessActor)
+        assert isinstance(restored[rel.target_id], BusinessProcess)
 
     def test_ids_are_bare_uuids_after_read(self, round_trip_model):
         tree = serialize_model(round_trip_model)

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -1199,9 +1199,11 @@ class TestIssue110ElementKeyedProfile:
         """
         original = self._build()
         restored = deserialize_model(serialize_model(original))
-        # Strip _owner from one element to provoke the required-check.
+        # Replace one element with a copy lacking _owner to provoke the
+        # required-check (concepts are immutable; ADR-051).
         target = next(e for e in restored.elements if isinstance(e, ApplicationComponent))
-        target.extended_attributes.pop("_owner", None)
+        stripped = {k: v for k, v in target.extended_attributes.items() if k != "_owner"}
+        restored._concepts[target.id] = target.model_copy(update={"extended_attributes": stripped})
         errors = [str(e) for e in restored.validate()]
         assert any("_owner" in msg and "required" in msg for msg in errors), errors
 

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -364,8 +364,8 @@ class TestRelationshipFactories:
         db = b.data_object("CustomerDB")
         rel = b.access(crm, db)
         assert isinstance(rel, Access)
-        assert rel.source is crm
-        assert rel.target is db
+        assert rel.source_id == crm.id
+        assert rel.target_id == db.id
 
     def test_serving_returns_serving_type(self) -> None:
         """serving() returns a Serving relationship."""
@@ -397,7 +397,7 @@ class TestRelationshipFactories:
         crm = b.application_component("CRM")
         db = b.data_object("CustomerDB")
         rel = b.access(crm.id, db)
-        assert rel.source is crm
+        assert rel.source_id == crm.id
 
     def test_string_id_resolution_target(self) -> None:
         """target can be passed as a string ID; builder resolves the element."""
@@ -407,7 +407,7 @@ class TestRelationshipFactories:
         crm = b.application_component("CRM")
         db = b.data_object("CustomerDB")
         rel = b.access(crm, db.id)
-        assert rel.target is db
+        assert rel.target_id == db.id
 
     def test_both_string_ids(self) -> None:
         """Both source and target can be passed as string IDs."""
@@ -417,8 +417,8 @@ class TestRelationshipFactories:
         actor = b.business_actor("Alice")
         role = b.business_role("Analyst")
         rel = b.assignment(actor.id, role.id)
-        assert rel.source is actor
-        assert rel.target is role
+        assert rel.source_id == actor.id
+        assert rel.target_id == role.id
 
     def test_unknown_string_id_raises(self) -> None:
         """Passing an unrecognised string ID raises KeyError or ValueError."""
@@ -628,8 +628,8 @@ class TestEdgeCases:
         actor = b.business_actor("Alice", id="actor-001")
         role = b.business_role("Analyst", id="role-001")
         rel = b.assignment("actor-001", "role-001")
-        assert rel.source is actor
-        assert rel.target is role
+        assert rel.source_id == actor.id
+        assert rel.target_id == role.id
 
 
 # ---------------------------------------------------------------------------
@@ -677,8 +677,8 @@ class TestFromDicts:
         assert len(model) == 3
         rels = [c for c in model.concepts if isinstance(c, Access)]
         assert len(rels) == 1
-        assert rels[0].source.id == "crm-1"
-        assert rels[0].target.id == "db-1"
+        assert rels[0].source_id == "crm-1"
+        assert rels[0].target_id == "db-1"
         assert rels[0].name == "reads"
 
     def test_from_dicts_unknown_type_raises(self) -> None:
@@ -877,8 +877,8 @@ class TestFromDataFrame:
         assert len(model) == 3
         rels = [c for c in model.concepts if isinstance(c, Access)]
         assert len(rels) == 1
-        assert rels[0].source.id == "crm-1"
-        assert rels[0].target.id == "db-1"
+        assert rels[0].source_id == "crm-1"
+        assert rels[0].target_id == "db-1"
         assert rels[0].name == "reads"
 
     def test_from_dataframe_custom_type_column(self) -> None:

--- a/test/test_impact.py
+++ b/test/test_impact.py
@@ -758,8 +758,8 @@ class TestResultModelDeepCopy:
         # endpoints are the same instances as in the original model.
         result_rel = result.resulting_model["rel-bc"]
         assert isinstance(result_rel, Relationship)
-        assert result_rel.source is b  # type: ignore[union-attr]
-        assert result_rel.target is c  # type: ignore[union-attr]
+        assert result_rel.source_id == b.id  # type: ignore[union-attr]
+        assert result_rel.target_id == c.id  # type: ignore[union-attr]
 
     def test_original_mutation_does_not_affect_result(self) -> None:
         """Mutating the original model after analysis does not alter resulting_model."""
@@ -971,7 +971,7 @@ class TestMergeBasic:
 
         # After merging A and B into T, relationships should use T as source
         rels_in_result = [c for c in result.resulting_model if isinstance(c, Relationship)]
-        source_ids = {r.source.id for r in rels_in_result}  # type: ignore[union-attr]
+        source_ids = {r.source_id for r in rels_in_result}  # type: ignore[union-attr]
         # T should be the source for the rewired relationships
         assert t.id in source_ids
         # A and B must not be sources in the result
@@ -1000,7 +1000,7 @@ class TestMergeDeduplication:
         tx_rels = [
             r
             for r in rels_in_result
-            if r.source.id == t.id and r.target.id == "x1"  # type: ignore[union-attr]
+            if r.source_id == t.id and r.target_id == "x1"  # type: ignore[union-attr]
         ]
         assert len(tx_rels) == 1
 
@@ -1078,7 +1078,7 @@ class TestMergeSelfLoop:
         self_loops = [
             r
             for r in rels_in_result
-            if r.source.id == t.id and r.target.id == t.id  # type: ignore[union-attr]
+            if r.source_id == t.id and r.target_id == t.id  # type: ignore[union-attr]
         ]
         assert len(self_loops) == 1
 
@@ -1117,7 +1117,7 @@ class TestMergeSelfMerge:
         ax_rels = [
             r
             for r in rels_in_result
-            if r.source.id == a.id and r.target.id == x.id  # type: ignore[union-attr]
+            if r.source_id == a.id and r.target_id == x.id  # type: ignore[union-attr]
         ]
         assert len(ax_rels) == 1
 
@@ -1214,11 +1214,11 @@ class TestReplaceBasic:
         assert result.resulting_model is not None
 
         rels_in_result = [c for c in result.resulting_model if isinstance(c, Relationship)]
-        source_ids = {r.source.id for r in rels_in_result}  # type: ignore[union-attr]
+        source_ids = {r.source_id for r in rels_in_result}  # type: ignore[union-attr]
         # new should be the source of the transferred relationship
         assert new.id in source_ids
         # old must not appear as source or target in any surviving relationship
-        target_ids = {r.target.id for r in rels_in_result}  # type: ignore[union-attr]
+        target_ids = {r.target_id for r in rels_in_result}  # type: ignore[union-attr]
         assert old.id not in source_ids
         assert old.id not in target_ids
 

--- a/test/test_impact.py
+++ b/test/test_impact.py
@@ -717,8 +717,13 @@ class TestByDepthOnRealResult:
 
 
 class TestResultModelDeepCopy:
-    def test_result_model_elements_are_copies(self) -> None:
-        """Elements in resulting_model are distinct objects (not the originals)."""
+    def test_result_model_shares_untouched_elements(self) -> None:
+        """Untouched elements are shared by reference (ADR-051 structural sharing).
+
+        Isolation is now guaranteed by immutability (frozen concepts), not by
+        producing distinct objects, so an unchanged survivor is the *same*
+        instance in both models.
+        """
         pytest.importorskip("networkx")
         from etcion.impact import analyze_impact
 
@@ -726,20 +731,19 @@ class TestResultModelDeepCopy:
         result = analyze_impact(model, remove=a)
         assert result.resulting_model is not None
 
-        # B survives; its copy in resulting_model must be a different object
+        # B survives untouched, so resulting_model shares the same instance.
         result_b = result.resulting_model["b1"]
-        assert id(result_b) != id(b)
-        # But the ArchiMate id field must be the same
+        assert result_b is b
         assert result_b.id == b.id
 
-    def test_result_relationships_reference_new_elements(self) -> None:
-        """Relationships in resulting_model reference the copied elements, not the originals."""
+    def test_result_relationships_reference_shared_elements(self) -> None:
+        """Surviving relationships reference the shared element instances (ADR-051)."""
         pytest.importorskip("networkx")
         from etcion.impact import analyze_impact
         from etcion.metamodel.business import BusinessActor, BusinessFunction, BusinessProcess
         from etcion.metamodel.concepts import Relationship
         from etcion.metamodel.model import Model
-        from etcion.metamodel.relationships import Assignment, Composition
+        from etcion.metamodel.relationships import Composition
 
         a = BusinessActor(id="a1", name="A")
         b = BusinessProcess(id="b1", name="B")
@@ -750,14 +754,12 @@ class TestResultModelDeepCopy:
         result = analyze_impact(model, remove=a)
         assert result.resulting_model is not None
 
-        # rel_bc survives (it does not touch A)
+        # rel_bc survives (it does not touch A) and is shared unchanged, so its
+        # endpoints are the same instances as in the original model.
         result_rel = result.resulting_model["rel-bc"]
         assert isinstance(result_rel, Relationship)
-        # source and target must be the copies from resulting_model, not the originals
-        assert id(result_rel.source) != id(b)  # type: ignore[union-attr]
-        assert id(result_rel.target) != id(c)  # type: ignore[union-attr]
-        assert result_rel.source.id == b.id  # type: ignore[union-attr]
-        assert result_rel.target.id == c.id  # type: ignore[union-attr]
+        assert result_rel.source is b  # type: ignore[union-attr]
+        assert result_rel.target is c  # type: ignore[union-attr]
 
     def test_original_mutation_does_not_affect_result(self) -> None:
         """Mutating the original model after analysis does not alter resulting_model."""
@@ -853,9 +855,9 @@ class TestResultModelJunction:
         assert "j1" in result_concept_ids
         assert "b1" in result_concept_ids
 
-        # Junction in result must be a copy, not the original
+        # Junction survives untouched, so it is shared by reference (ADR-051).
         result_j = result.resulting_model["j1"]
-        assert id(result_j) != id(j)
+        assert result_j is j
         assert result_j.id == j.id
 
 

--- a/test/test_impact.py
+++ b/test/test_impact.py
@@ -1786,3 +1786,123 @@ class TestImpactResultToDict:
             assert layer_val is None or isinstance(layer_val, str), (
                 f"layer must be str or None, got {type(layer_val)!r}: {layer_val!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# ADR-051: TestSubstitute — substitute/version semantics for replace
+# ---------------------------------------------------------------------------
+
+
+class TestSubstitute:
+    """``analyze_impact(substitute=(old, new))`` — new takes old's identity slot."""
+
+    @staticmethod
+    def _serving_model():
+        from etcion.metamodel.business import BusinessProcess, BusinessService
+        from etcion.metamodel.model import Model
+        from etcion.metamodel.relationships import Serving
+
+        # BusinessService -Serving-> BusinessProcess is permitted.
+        svc = BusinessService(id="svc1", name="Svc")
+        proc = BusinessProcess(id="proc1", name="Proc")
+        rel = Serving(id="rel-sp", name="SP", source=svc, target=proc)
+        return Model(concepts=[svc, proc, rel]), svc, proc, rel
+
+    def test_new_takes_old_id_slot(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, _proc, _rel = self._serving_model()
+        new = BusinessService(id="svc1", name="Svc v2")
+
+        result = analyze_impact(model, substitute=(svc, new))
+
+        assert result.resulting_model is not None
+        assert result.resulting_model["svc1"].name == "Svc v2"
+
+    def test_relationships_untouched_resolve_to_new(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, _proc, rel = self._serving_model()
+        new = BusinessService(id="svc1", name="Svc v2")
+
+        result = analyze_impact(model, substitute=(svc, new))
+        rm = result.resulting_model
+        assert rm is not None
+        # The relationship still references "svc1" by ID; it now resolves to new.
+        result_rel = rm["rel-sp"]
+        assert result_rel.source_id == "svc1"
+        assert rm[result_rel.source_id].name == "Svc v2"
+
+    def test_original_is_unchanged(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, _proc, _rel = self._serving_model()
+        analyze_impact(model, substitute=(svc, BusinessService(id="svc1", name="Svc v2")))
+        assert model["svc1"].name == "Svc"
+
+    def test_affected_reports_direct_neighbours(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, proc, _rel = self._serving_model()
+        result = analyze_impact(model, substitute=(svc, BusinessService(id="svc1", name="v2")))
+        affected_ids = {ic.concept.id for ic in result.affected}
+        assert affected_ids == {proc.id}
+        assert all(ic.depth == 1 for ic in result.affected)
+
+    def test_same_type_no_violations(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, _proc, _rel = self._serving_model()
+        result = analyze_impact(model, substitute=(svc, BusinessService(id="svc1", name="v2")))
+        assert result.violations == ()
+        assert result.broken_relationships == ()
+
+    def test_incompatible_type_creates_violation(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import Violation, analyze_impact
+        from etcion.metamodel.business import BusinessActor
+
+        # BusinessService -Serving-> BusinessProcess is permitted, but
+        # BusinessActor -Serving-> BusinessProcess is NOT.
+        model, svc, _proc, rel = self._serving_model()
+        result = analyze_impact(model, substitute=(svc, BusinessActor(id="svc1", name="Actor")))
+
+        assert len(result.violations) > 0
+        assert all(isinstance(v, Violation) for v in result.violations)
+        assert any(v.relationship.id == rel.id for v in result.violations)
+
+    def test_new_rekeyed_when_ids_differ(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, _proc, _rel = self._serving_model()
+        # new carries a different id; it should be re-keyed into old's slot.
+        new = BusinessService(id="different-id", name="v2")
+        result = analyze_impact(model, substitute=(svc, new))
+        rm = result.resulting_model
+        assert rm is not None
+        assert rm["svc1"].name == "v2"
+        assert "different-id" not in {c.id for c in rm}
+
+    def test_untouched_concepts_shared(self) -> None:
+        pytest.importorskip("networkx")
+        from etcion.impact import analyze_impact
+        from etcion.metamodel.business import BusinessService
+
+        model, svc, proc, rel = self._serving_model()
+        result = analyze_impact(model, substitute=(svc, BusinessService(id="svc1", name="v2")))
+        rm = result.resulting_model
+        assert rm is not None
+        assert rm["proc1"] is proc
+        assert rm["rel-sp"] is rel

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -19,7 +19,7 @@ class TestVersionExposed:
     """etcion.__version__ is publicly accessible and correct."""
 
     def test_version_exposed(self) -> None:
-        assert etcion.__version__ == "0.12.0"
+        assert etcion.__version__ == "0.13.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(etcion.__version__, str)

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -69,7 +69,7 @@ class TestProjectMetadata:
 
     def test_project_version(self) -> None:
         data = _load_toml()
-        assert data["project"]["version"] == "0.13.0"
+        assert data["project"]["version"] == "0.12.0"
 
     def test_requires_python(self) -> None:
         data = _load_toml()

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -69,7 +69,7 @@ class TestProjectMetadata:
 
     def test_project_version(self) -> None:
         data = _load_toml()
-        assert data["project"]["version"] == "0.12.0"
+        assert data["project"]["version"] == "0.13.0"
 
     def test_requires_python(self) -> None:
         data = _load_toml()


### PR DESCRIPTION
## Summary

**0.13.0 — Structural sharing for impact analysis and model editing** ([ADR-051](docs/adr/ADR-051-copy-on-write-result-models.md), closes #113).

`analyze_impact` / `chain_impacts` no longer deep-copy the entire model to build `resulting_model`; a single-concept operation is now `O(affected)` rather than `O(model_size)`. A 1-element remove on a 150K-concept model drops from the multi-second range to ~1s (dominated by graph construction, not copying), and a rename is ~6ms.

### Breaking changes
1. **Concepts are immutable (frozen).** Use `concept.model_copy(update={...})` instead of attribute assignment.
2. **`resulting_model` shares untouched concepts by reference** — rely on immutability for isolation, not `id()` distinctness.
3. **Relationship endpoints by ID** — `source_id` / `target_id`; resolve via `model[rel.source_id]`. Wire format unchanged.
4. **`extended_attributes` is an immutable mapping** (`FrozenMap`).
5. **`assigned_elements` / `members` are tuples.**

### Added
- `analyze_impact(substitute=(old, new))` — substitute/version semantics alongside `replace=` (redirect).
- Structural-sharing editing API: `Model.with_added` / `with_replaced` / `with_removed`.

See the CHANGELOG `[0.13.0]` entry for full migration notes.

## Closes
Closes #113.