### PR TITLE
fix(xml): NCName-safe identifiers on Exchange Format write (#117)

### DIFF
--- a/docs/adr/ADR-031-epic019-serialization.md
+++ b/docs/adr/ADR-031-epic019-serialization.md
@@ -212,3 +212,40 @@ Serializing Model to dict (via Pydantic), then dict to XML. Rejected because:
 - Users must import from `etcion.serialization.xml` rather than calling `model.to_xml()`. This is less discoverable but consistent with the library's separation of concerns.
 - The type registry must be kept in sync with the metamodel class hierarchy. A missing registration is a silent bug until a serialization test catches it.
 - Opaque XML preservation (`_opaque_xml`) adds memory overhead proportional to unrecognized content. For models with large view sections, this could be significant.
+
+## Addendum (2026-06-28): NCName-safe identifiers on write (#117)
+
+This addendum amends **Decision 4 (Identifier Format)** and **Decision 8 (XSD Validation)** in response to issue #117. It does not reopen those decisions; it constrains one edge they left open.
+
+### Problem
+
+`Concept.id` accepts any non-empty string (ADR-006: the ArchiMate spec mandates only uniqueness, not a format). On write, `_to_exchange_id()` prepends `id-` and emits the value verbatim into the `identifier` attribute (Decision 4). The Exchange Format XSD types every `identifier`/`source`/`target`/`*Ref` attribute as `xs:ID`/`xs:IDREF`, both derived from XML `NCName` — which forbids `:`, `/`, spaces, and a leading digit, among others.
+
+The result: a user-supplied id such as `api:default/load-template-api` produces XML that fails the bundled XSD. Because validation is opt-in (Decision 8), the library emitted non-conformant XML with no signal. Archi rejected it on import with `cvc-datatype-valid.1.2.1: ... is not a valid value for 'NCName'`.
+
+The in-memory model staying format-agnostic is correct (ADR-006) — a model may only ever be exported to JSON/CSV/graph, where NCName is irrelevant. The constraint is a property of the *Exchange Format serialization target*, so it is enforced at the serialization boundary, not on `Concept.id`.
+
+### Scope of the failure mode
+
+An audit of the serializer found that **every** user-controlled value reaching an `xs:ID`/`xs:IDREF` slot comes from one of four sources. All other user-controlled output (`name`, `documentation`, specialization/property values, model name) lands in `xs:string`, which has no lexical constraint and needs no validation. `xml:lang` is a hard-coded constant. There is therefore no need for a general "validate the whole tree on write" path; the failure surface is closed at these four sources:
+
+| User source | XML slot(s) | XSD type |
+|---|---|---|
+| `Concept.id` | element/relationship `@identifier`; transitively `node/@elementRef`, `connection/@relationshipRef` | `xs:ID` / `xs:IDREF` |
+| `Relationship.source_id` | relationship `@source` | `xs:IDREF` |
+| `Relationship.target_id` | relationship `@target` | `xs:IDREF` |
+| `extended_attributes` keys | `property/@propertyDefinitionRef` **and** `propertyDefinition/@identifier` | `xs:IDREF` + `xs:ID` |
+
+The `extended_attributes` keys are the non-obvious vector: a single malformed key violates the schema in two places (the `propertyDefinition` that declares it and every `property` that references it).
+
+### Decision
+
+`write_model()` / `serialize_model()` gain an `on_invalid_id` policy parameter governing what happens when any of the four sources produces a value that is not a valid `NCName` (after `id-` prefixing):
+
+- `"raise"` (**default**) — collect **all** offending values in one pass and raise a single typed exception (e.g. `InvalidExchangeIdentifierError`) carrying the full `{value: reason}` mapping. The "everything we emit conforms to the bundled XSD" contract holds unless explicitly waived.
+- `"sanitize"` — deterministically rewrite offending values to valid NCNames via the existing bidirectional id-map (Decision 4), collision-safely (a sanitized value that collides with another id must be disambiguated). `source`/`target`/`*Ref` resolve through the same map, so references are fixed consistently for free. The caller's model object is **not** mutated; the rewrite happens only in the emitted tree.
+- `"allow"` — emit verbatim (the pre-#117 behavior), for callers whose downstream consumer is lenient.
+
+Rationale for raise-as-default over silent sanitize: the offending ids are frequently meaningful external-system keys, and silently rewriting them breaks traceability and any external references. Failing loud and early is more debuggable than ids that silently changed shape. The check is a cheap regex over a bounded set, so it is on by default; full XSD validation (Decision 8) remains the authoritative, opt-in superset behind it.
+
+This is intentionally not a Pydantic validator on `Concept.id` — that would violate ADR-006 and reject valid models destined for non-XML formats.

--- a/src/etcion/__init__.py
+++ b/src/etcion/__init__.py
@@ -36,6 +36,7 @@ from etcion.enums import (
 from etcion.exceptions import (
     ConformanceError,
     DerivationError,
+    InvalidExchangeIdentifierError,
     PyArchiError,
     ValidationError,
 )
@@ -227,6 +228,7 @@ __all__: list[str] = [
     "ValidationError",
     "DerivationError",
     "ConformanceError",
+    "InvalidExchangeIdentifierError",
     # conformance (FEAT-01.1)
     "ConformanceProfile",
     "CONFORMANCE",

--- a/src/etcion/exceptions.py
+++ b/src/etcion/exceptions.py
@@ -25,3 +25,28 @@ class DerivationError(PyArchiError):
 
 class ConformanceError(PyArchiError):
     """Raised when a model fails a conformance check against the ArchiMate 3.2 specification."""
+
+
+class InvalidExchangeIdentifierError(PyArchiError):
+    """Raised when XML serialization would emit an identifier that is not a valid NCName.
+
+    The ArchiMate Exchange Format types every ``identifier`` / ``source`` /
+    ``target`` / ``*Ref`` attribute as ``xs:ID`` / ``xs:IDREF``, both derived
+    from XML ``NCName`` (no ``:``, ``/`` or spaces; no leading digit).
+    ``Concept.id``, ``Relationship.source_id`` / ``target_id`` and
+    ``extended_attributes`` keys accept arbitrary strings (ADR-006), so this
+    guards the serialization boundary (ADR-031 addendum, Issue #117).
+
+    :attr:`invalid` maps each offending identifier (as it would appear in the
+    XML, i.e. after the ``id-`` prefix is applied) to the reason it is invalid.
+    """
+
+    def __init__(self, invalid: dict[str, str]) -> None:
+        self.invalid = dict(invalid)
+        detail = "\n".join(f"  {value!r}: {reason}" for value, reason in invalid.items())
+        super().__init__(
+            f"{len(invalid)} identifier(s) are not valid XML NCNames and cannot be written "
+            f"to the ArchiMate Exchange Format:\n{detail}\n"
+            "Fix the offending identifiers, or pass on_invalid_id='sanitize' to rewrite "
+            "them automatically (or on_invalid_id='allow' to emit them verbatim)."
+        )

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -6,10 +6,11 @@ Reference: ADR-031.
 from __future__ import annotations
 
 import json
+import re
 import uuid
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 try:
     from lxml import etree
@@ -18,6 +19,7 @@ except ImportError as exc:
         "lxml is required for XML serialization. Install it with: pip install etcion[xml]"
     ) from exc
 
+from etcion.exceptions import InvalidExchangeIdentifierError
 from etcion.metamodel.concepts import Concept, Element, Relationship
 from etcion.metamodel.model import Model
 from etcion.metamodel.profiles import Profile
@@ -81,6 +83,107 @@ def _to_exchange_id(internal_id: str) -> str:
     return internal_id if internal_id.startswith("id-") else f"id-{internal_id}"
 
 
+# Policy governing identifiers that are not valid XML NCNames on write (#117).
+OnInvalidId = Literal["raise", "sanitize", "allow"]
+
+# XML NCName character classes (XML 1.0 NameStartChar/NameChar minus ':').
+# Covers ASCII plus the common Unicode ranges; the rarely-used astral planes
+# (>= U+10000) are omitted for simplicity.
+_NCNAME_START = (
+    "A-Za-z_"
+    "\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02ff\u0370-\u037d\u037f-\u1fff"
+    "\u200c-\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd"
+)
+_NCNAME_CHAR = _NCNAME_START + "\\-.0-9\u00b7\u0300-\u036f\u203f-\u2040"
+_NCNAME_START_RE = re.compile(f"[{_NCNAME_START}]")
+_NCNAME_CHAR_RE = re.compile(f"[{_NCNAME_CHAR}]")
+_NCNAME_RE = re.compile(f"^[{_NCNAME_START}][{_NCNAME_CHAR}]*$")
+
+
+def _ncname_violation(value: str) -> str | None:
+    """Return a human-readable reason *value* is not a valid NCName, else ``None``."""
+    if value == "":
+        return "empty identifier"
+    if _NCNAME_RE.match(value):
+        return None
+    if not _NCNAME_START_RE.match(value[0]):
+        return f"must start with a letter or underscore, not {value[0]!r}"
+    illegal = sorted({c for c in value if not _NCNAME_CHAR_RE.match(c)})
+    if illegal:
+        chars = ", ".join(repr(c) for c in illegal)
+        return f"contains characters not allowed in an NCName: {chars}"
+    return "not a valid NCName"  # pragma: no cover - defensive
+
+
+def _sanitize_ncname(value: str) -> str:
+    """Rewrite *value* into a valid NCName by replacing illegal characters with ``-``."""
+    out = "".join(c if _NCNAME_CHAR_RE.match(c) else "-" for c in value)
+    if not out or not _NCNAME_START_RE.match(out[0]):
+        out = "_" + out
+    return out
+
+
+class _IdMapper:
+    """Maps internal/raw identifiers to NCName-safe Exchange Format identifiers.
+
+    A single instance is shared across a whole ``serialize_model`` call so that
+    every reference to a given identifier (an element id and the ``source`` /
+    ``target`` / ``elementRef`` / ``relationshipRef`` that point at it, or a
+    ``propertyDefinition`` id and the ``propertyDefinitionRef`` that cites it)
+    resolves to the same output — keeping ID/IDREF pairings intact even when
+    sanitization rewrites a value (ADR-031 addendum, #117).
+
+    When ``sanitize`` is false, invalid identifiers pass through verbatim and are
+    recorded in :attr:`invalid`; the caller decides whether to raise (``"raise"``)
+    or emit them anyway (``"allow"``).
+    """
+
+    def __init__(self, *, sanitize: bool) -> None:
+        self._sanitize = sanitize
+        self._cache: dict[str, str] = {}
+        self._used: set[str] = set()
+        self.invalid: dict[str, str] = {}
+
+    def concept(self, internal_id: str) -> str:
+        """Map a concept's internal id to its (validated) Exchange Format id."""
+        return self._map(_to_exchange_id(internal_id))
+
+    def propdef(self, raw_id: str) -> str:
+        """Map a ``propdef-*`` identifier (built from a user-supplied attr name)."""
+        return self._map(raw_id)
+
+    def _map(self, raw: str) -> str:
+        cached = self._cache.get(raw)
+        if cached is not None:
+            return cached
+        reason = _ncname_violation(raw)
+        if reason is None:
+            # In sanitize mode, dedupe even already-valid ids so a sanitized
+            # value can never collide with a verbatim one (xs:ID uniqueness).
+            result = self._unique(raw) if self._sanitize else raw
+        elif self._sanitize:
+            result = self._unique(_sanitize_ncname(raw))
+        else:
+            self.invalid[raw] = reason
+            result = raw
+        self._cache[raw] = result
+        self._used.add(result)
+        return result
+
+    def _unique(self, candidate: str) -> str:
+        if candidate not in self._used:
+            return candidate
+        suffix = 2
+        while f"{candidate}-{suffix}" in self._used:
+            suffix += 1
+        return f"{candidate}-{suffix}"
+
+
+def _default_mapper(id_mapper: _IdMapper | None) -> _IdMapper:
+    """Return *id_mapper* or a permissive standalone mapper (verbatim, never raises)."""
+    return id_mapper if id_mapper is not None else _IdMapper(sanitize=False)
+
+
 def _expanded_attribute_extensions(
     profile: Profile, present_types: set[type[Concept]]
 ) -> dict[type[Concept], dict[str, Any]]:
@@ -105,11 +208,16 @@ def _expanded_attribute_extensions(
     return expanded
 
 
-def serialize_element(elem: Element) -> etree._Element:
-    """Serialize a single Element to an lxml element node."""
+def serialize_element(elem: Element, *, id_mapper: _IdMapper | None = None) -> etree._Element:
+    """Serialize a single Element to an lxml element node.
+
+    *id_mapper* (internal) carries the NCName-safety policy across a full model
+    serialization; when omitted, identifiers are emitted verbatim (#117).
+    """
+    mapper = _default_mapper(id_mapper)
     desc = TYPE_REGISTRY[type(elem)]
     el = etree.Element(f"{{{ARCHIMATE_NS}}}element", nsmap=NSMAP)
-    el.set("identifier", _to_exchange_id(elem.id))
+    el.set("identifier", mapper.concept(elem.id))
     el.set(f"{{{XSI_NS}}}type", desc.xml_tag)
 
     name_el = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}name")
@@ -136,7 +244,9 @@ def serialize_element(elem: Element) -> etree._Element:
             type_name = TYPE_REGISTRY[type(elem)].xml_tag
             for attr_name, value in elem.extended_attributes.items():
                 prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
-                prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+                prop_el.set(
+                    "propertyDefinitionRef", mapper.propdef(f"propdef-{type_name}-{attr_name}")
+                )
                 val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
                 val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
                 val_el.text = str(value)
@@ -144,7 +254,9 @@ def serialize_element(elem: Element) -> etree._Element:
     return el
 
 
-def serialize_relationship(rel: Relationship) -> etree._Element:
+def serialize_relationship(
+    rel: Relationship, *, id_mapper: _IdMapper | None = None
+) -> etree._Element:
     """Serialize a single Relationship to an lxml element node.
 
     Per ADR-050, ``extended_attributes`` declared on a Relationship are
@@ -152,12 +264,16 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
     propdef-id scheme namespaces by the relationship's xml_tag so collisions
     with element propdefs are not possible (relationship and element xml_tag
     spaces are disjoint).
+
+    *id_mapper* (internal) carries the NCName-safety policy across a full model
+    serialization; when omitted, identifiers are emitted verbatim (#117).
     """
+    mapper = _default_mapper(id_mapper)
     desc = TYPE_REGISTRY[type(rel)]
     el = etree.Element(f"{{{ARCHIMATE_NS}}}relationship", nsmap=NSMAP)
-    el.set("identifier", _to_exchange_id(rel.id))
-    el.set("source", _to_exchange_id(rel.source_id))
-    el.set("target", _to_exchange_id(rel.target_id))
+    el.set("identifier", mapper.concept(rel.id))
+    el.set("source", mapper.concept(rel.source_id))
+    el.set("target", mapper.concept(rel.target_id))
     el.set(f"{{{XSI_NS}}}type", desc.xml_tag)
 
     if rel.name:
@@ -170,7 +286,7 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
         type_name = desc.xml_tag
         for attr_name, value in rel.extended_attributes.items():
             prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
-            prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+            prop_el.set("propertyDefinitionRef", mapper.propdef(f"propdef-{type_name}-{attr_name}"))
             val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
             val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
             val_el.text = str(value)
@@ -183,7 +299,9 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
     return el
 
 
-def _serialize_view(view: View, parent: etree._Element) -> None:
+def _serialize_view(
+    view: View, parent: etree._Element, *, id_mapper: _IdMapper | None = None
+) -> None:
     """Serialize a single View as a ``<view>`` element appended to *parent*.
 
     Emits ``<node>`` children for every :class:`~etcion.metamodel.concepts.Element`
@@ -193,6 +311,7 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
     Connections whose source or target element is absent from the view are
     silently skipped.
     """
+    mapper = _default_mapper(id_mapper)
     view_id = f"id-view-{uuid.uuid4()}"
     view_el = etree.SubElement(parent, f"{{{ARCHIMATE_NS}}}view")
     view_el.set("identifier", view_id)
@@ -219,7 +338,7 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
         col = index % _columns
         row = index // _columns
         node_id = f"id-node-{uuid.uuid4()}"
-        exchange_id = _to_exchange_id(elem.id)
+        exchange_id = mapper.concept(elem.id)
         elem_exchange_id_to_node_id[exchange_id] = node_id
 
         node_el = etree.SubElement(view_el, f"{{{ARCHIMATE_NS}}}node")
@@ -232,8 +351,8 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
         node_el.set("h", str(_node_h))
 
     for rel in view_relationships:
-        src_exchange_id = _to_exchange_id(rel.source_id)
-        tgt_exchange_id = _to_exchange_id(rel.target_id)
+        src_exchange_id = mapper.concept(rel.source_id)
+        tgt_exchange_id = mapper.concept(rel.target_id)
         src_node_id = elem_exchange_id_to_node_id.get(src_exchange_id)
         tgt_node_id = elem_exchange_id_to_node_id.get(tgt_exchange_id)
         # Skip connections whose endpoints have no node in this view.
@@ -242,14 +361,32 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
 
         conn_el = etree.SubElement(view_el, f"{{{ARCHIMATE_NS}}}connection")
         conn_el.set("identifier", f"id-conn-{uuid.uuid4()}")
-        conn_el.set("relationshipRef", _to_exchange_id(rel.id))
+        conn_el.set("relationshipRef", mapper.concept(rel.id))
         conn_el.set(f"{{{XSI_NS}}}type", "Relationship")
         conn_el.set("source", src_node_id)
         conn_el.set("target", tgt_node_id)
 
 
-def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etree._ElementTree:
-    """Serialize a Model to a complete Exchange Format ElementTree."""
+def serialize_model(
+    model: Model,
+    *,
+    model_name: str = "Untitled Model",
+    on_invalid_id: OnInvalidId = "raise",
+) -> etree._ElementTree:
+    """Serialize a Model to a complete Exchange Format ElementTree.
+
+    *on_invalid_id* governs identifiers that are not valid XML ``NCName`` values
+    once written (element/relationship ids, relationship ``source``/``target``,
+    and ``extended_attributes`` keys — the only user-controlled values that
+    reach ``xs:ID``/``xs:IDREF`` slots; see ADR-031 addendum, #117):
+
+    - ``"raise"`` (default): collect every offending identifier and raise
+      :class:`~etcion.exceptions.InvalidExchangeIdentifierError`.
+    - ``"sanitize"``: rewrite offending identifiers to valid NCNames, keeping
+      ID/IDREF pairings consistent. The *model* object is not mutated.
+    - ``"allow"``: emit identifiers verbatim (pre-#117 behavior).
+    """
+    mapper = _IdMapper(sanitize=(on_invalid_id == "sanitize"))
     root = etree.Element(f"{{{ARCHIMATE_NS}}}model", nsmap=NSMAP)
     root.set("identifier", "id-model-root")
     root.set(f"{{{XSI_NS}}}schemaLocation", ARCHIMATE_SCHEMA_LOCATION)
@@ -260,11 +397,11 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
 
     elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
     for elem in model.elements:
-        elements_container.append(serialize_element(elem))
+        elements_container.append(serialize_element(elem, id_mapper=mapper))
 
     rels_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}relationships")
     for rel in model.relationships:
-        rels_container.append(serialize_relationship(rel))
+        rels_container.append(serialize_relationship(rel, id_mapper=mapper))
 
     opaque = getattr(model, "_opaque_xml", [])
     for node in opaque:
@@ -328,7 +465,7 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
                         raw_value if isinstance(raw_value, type) else raw_value["type"]
                     )
                     pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
-                    pd.set("identifier", f"propdef-{type_name}-{attr_name}")
+                    pd.set("identifier", mapper.propdef(f"propdef-{type_name}-{attr_name}"))
                     pd.set("type", _PY_TO_XSD_TYPE.get(attr_type.__name__, "string"))
                     pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
                     pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
@@ -336,7 +473,7 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
 
         for pid, attr_name in undeclared.items():
             pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
-            pd.set("identifier", pid)
+            pd.set("identifier", mapper.propdef(pid))
             pd.set("type", "string")
             pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
             pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
@@ -372,7 +509,12 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
         views_el = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}views")
         diagrams_el = etree.SubElement(views_el, f"{{{ARCHIMATE_NS}}}diagrams")
         for view in model.views:
-            _serialize_view(view, diagrams_el)
+            _serialize_view(view, diagrams_el, id_mapper=mapper)
+
+    # Under the default "raise" policy, fail once with every offending id rather
+    # than emitting XML that violates the bundled XSD (ADR-031 addendum, #117).
+    if on_invalid_id == "raise" and mapper.invalid:
+        raise InvalidExchangeIdentifierError(mapper.invalid)
 
     return etree.ElementTree(root)
 
@@ -414,9 +556,19 @@ def _collect_constraint_profiles(
     return result
 
 
-def write_model(model: Model, path: str | Path, *, model_name: str = "Untitled Model") -> None:
-    """Write a Model to an XML file in Exchange Format."""
-    tree = serialize_model(model, model_name=model_name)
+def write_model(
+    model: Model,
+    path: str | Path,
+    *,
+    model_name: str = "Untitled Model",
+    on_invalid_id: OnInvalidId = "raise",
+) -> None:
+    """Write a Model to an XML file in Exchange Format.
+
+    *on_invalid_id* controls handling of identifiers that are not valid XML
+    ``NCName`` values; see :func:`serialize_model` (#117).
+    """
+    tree = serialize_model(model, model_name=model_name, on_invalid_id=on_invalid_id)
     etree.indent(tree, space="  ")
     tree.write(
         str(path),

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -13,6 +13,7 @@ from lxml import etree
 lxml = pytest.importorskip("lxml")
 
 from etcion.enums import AccessMode, ContentCategory, InfluenceSign, PurposeCategory  # noqa: E402
+from etcion.exceptions import InvalidExchangeIdentifierError  # noqa: E402
 from etcion.metamodel.application import (  # noqa: E402
     ApplicationComponent,
     DataObject,  # noqa: E402
@@ -44,6 +45,8 @@ from etcion.serialization.registry import (  # noqa: E402
 )
 from etcion.serialization.xml import (  # noqa: E402  # noqa: E402  # noqa: E402  # noqa: E402  # noqa: E402
     _from_exchange_id,
+    _ncname_violation,
+    _sanitize_ncname,
     _to_exchange_id,
     deserialize_model,
     read_model,
@@ -1231,3 +1234,113 @@ class TestIssue110ElementKeyedProfile:
         type_by_id = {pd.get("identifier"): pd.get("type") for pd in pd_container}
         # int -> XSD "number"; if Element's str had won we'd see "string".
         assert type_by_id["propdef-ApplicationComponent-_owner"] == "number"
+
+
+class TestNCNameHelpers:
+    """Unit tests for the NCName validation/sanitization primitives (#117)."""
+
+    def test_valid_ncname_returns_none(self) -> None:
+        assert _ncname_violation("id-good_id.1") is None
+
+    def test_colon_and_slash_rejected(self) -> None:
+        reason = _ncname_violation("id-api:default/load")
+        assert reason is not None
+        assert "'/'" in reason and "':'" in reason
+
+    def test_space_rejected(self) -> None:
+        assert _ncname_violation("id-a b") is not None
+
+    def test_empty_rejected(self) -> None:
+        assert _ncname_violation("") == "empty identifier"
+
+    def test_leading_digit_rejected(self) -> None:
+        # A bare value (no id- prefix) starting with a digit is not a valid start.
+        reason = _ncname_violation("3abc")
+        assert reason is not None and "start" in reason
+
+    def test_sanitize_replaces_illegal_chars(self) -> None:
+        assert _sanitize_ncname("id-api:default/load") == "id-api-default-load"
+
+    def test_sanitize_yields_valid_ncname(self) -> None:
+        assert _ncname_violation(_sanitize_ncname("3 weird/id:x")) is None
+
+
+class TestOnInvalidIdPolicy:
+    """write/serialize_model behavior for non-NCName identifiers (#117)."""
+
+    def _model_with_bad_ids(self) -> Model:
+        m = Model()
+        a = ApplicationComponent(id="api:default/load-template-api", name="API")
+        b = BusinessService(id="svc 1", name="Svc")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(id="rel:1", source_id=a.id, target_id=b.id, name="serves"))
+        return m
+
+    def test_raise_is_default(self) -> None:
+        with pytest.raises(InvalidExchangeIdentifierError) as exc_info:
+            serialize_model(self._model_with_bad_ids())
+        # All three offending ids are reported in a single pass.
+        assert len(exc_info.value.invalid) == 3
+
+    def test_write_model_raises_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.xml"
+            with pytest.raises(InvalidExchangeIdentifierError):
+                write_model(self._model_with_bad_ids(), path)
+
+    def test_allow_emits_verbatim(self) -> None:
+        tree = serialize_model(self._model_with_bad_ids(), on_invalid_id="allow")
+        ids = {el.get("identifier") for el in tree.iter() if el.get("identifier")}
+        assert "id-api:default/load-template-api" in ids
+
+    def test_sanitize_produces_xsd_valid_output(self) -> None:
+        tree = serialize_model(self._model_with_bad_ids(), on_invalid_id="sanitize")
+        assert validate_exchange_format(tree) == []
+
+    def test_sanitize_keeps_source_target_consistent(self) -> None:
+        tree = serialize_model(self._model_with_bad_ids(), on_invalid_id="sanitize")
+        root = tree.getroot()
+        # Collect element identifiers and the relationship's source/target.
+        elem_ids = {el.get("identifier") for el in root.iter(f"{{{ARCHIMATE_NS}}}element")}
+        rel = root.find(f"{{{ARCHIMATE_NS}}}relationships/{{{ARCHIMATE_NS}}}relationship")
+        assert rel is not None
+        assert rel.get("source") in elem_ids
+        assert rel.get("target") in elem_ids
+
+    def test_sanitize_does_not_mutate_model(self) -> None:
+        model = self._model_with_bad_ids()
+        serialize_model(model, on_invalid_id="sanitize")
+        # Original ids on the in-memory model are untouched.
+        assert any(e.id == "api:default/load-template-api" for e in model.elements)
+
+    def test_extended_attribute_key_is_validated(self) -> None:
+        # A bad extended_attributes key reaches both an xs:ID and an xs:IDREF.
+        m = Model()
+        m.add(ApplicationComponent(name="App", extended_attributes={"bad key/x": 1}))
+        with pytest.raises(InvalidExchangeIdentifierError) as exc_info:
+            serialize_model(m)
+        assert any("bad key/x" in k for k in exc_info.value.invalid)
+
+    def test_extended_attribute_key_sanitized_consistently(self) -> None:
+        m = Model()
+        a = ApplicationComponent(name="App", extended_attributes={"bad key/x": 1})
+        b = BusinessService(name="Svc")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(source_id=a.id, target_id=b.id))  # keep the model XSD-valid
+        tree = serialize_model(m, on_invalid_id="sanitize")
+        # The property ref and the propertyDefinition id must still match,
+        # which the XSD's IDREF->ID keyref enforces.
+        assert validate_exchange_format(tree) == []
+
+    def test_valid_uuid_model_unaffected(self) -> None:
+        # The default policy must not disturb ordinary UUID-id models.
+        m = Model()
+        a = ApplicationComponent(name="A")
+        b = BusinessService(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(source_id=a.id, target_id=b.id))
+        tree = serialize_model(m)  # default "raise" — should not raise
+        assert validate_exchange_format(tree) == []


### PR DESCRIPTION
Closes #117.

## Problem

User-supplied identifiers that reach `xs:ID` / `xs:IDREF` slots in the ArchiMate Exchange Format can contain characters illegal in an XML `NCName` (`:`, `/`, spaces, leading digit). The serializer emitted these verbatim, producing XML that fails the bundled XSD and is rejected by Archi on import — with no signal to the user.

Reported value from #117: `id-api:default/load-template-api` → `cvc-datatype-valid.1.2.1: ... is not a valid value for 'NCName'`.

## Fix

An audit found exactly four user-controlled sources that reach NCName-typed slots; everything else lands in `xs:string` (no constraint), so there is no need for a general validator:

- `Concept.id` (element/relationship `@identifier`; transitively `node/@elementRef`, `connection/@relationshipRef`)
- `Relationship.source_id` / `target_id` (`@source` / `@target`)
- `extended_attributes` keys (`propertyDefinitionRef` **and** `propertyDefinition/@identifier`)

`serialize_model()` / `write_model()` gain an `on_invalid_id` policy:

| value | behavior |
|---|---|
| `"raise"` (**default**) | collect **all** offending ids and raise `InvalidExchangeIdentifierError` in one pass |
| `"sanitize"` | rewrite ids to valid NCNames via a shared `_IdMapper` that keeps ID/IDREF pairings consistent and unique; the model object is **not** mutated |
| `"allow"` | emit verbatim (pre-fix behavior) |

The check is a cheap regex over the four sources, on by default. `validate_exchange_format()` remains the authoritative full-XSD superset behind it. `Concept.id` stays format-agnostic (ADR-006) — this is enforced only at the serialization boundary.

Design decision recorded as an addendum to **ADR-031** (included in this branch).

## Behavior change

The default policy is now `raise`, so a model with non-NCName ids that previously wrote silently-broken XML will now error. This is the intended contract; no existing test relied on the old behavior.

## Tests

`TestNCNameHelpers` + `TestOnInvalidIdPolicy` cover: raise-by-default, `write_model` raises, allow-verbatim, sanitize → XSD-valid output, sanitize keeps source/target consistent, sanitize does not mutate the model, extended-attribute keys validated + sanitized consistently, and valid-UUID models unaffected.

Full suite green; `ruff check` / `ruff format --check` / `mypy` clean.

## Follow-ups (separate issues, found during the audit)
- #118 — Influence/Junction mapping bugs (non-conformant regardless of input)
- #119 — `validate_exchange_format()` only loads the Model XSD