### PR TITLE
fix(xml): junctions, conformant Influence modifier, non-empty containers, full-schema validation (#118 #121 #119)

### DIFF
--- a/src/etcion/serialization/registry.py
+++ b/src/etcion/serialization/registry.py
@@ -222,11 +222,14 @@ def _register_all() -> None:
         xml_tag="Access",
         extra_attrs={"accessType": lambda r: _enum_val(r, "access_mode")},
     )
+    # The Exchange Format folds sign *and* strength into the single optional
+    # @modifier attribute (InfluenceModifierType = union(InfluenceStrengthEnum,
+    # xs:string)); there is no @strength attribute (#118).  Prefer the free-text
+    # strength when set, else fall back to the sign enum value.
     TYPE_REGISTRY[Influence] = TypeDescriptor(
         xml_tag="Influence",
         extra_attrs={
-            "modifier": lambda r: _enum_val(r, "sign"),
-            "strength": lambda r: r.strength,
+            "modifier": lambda r: r.strength if r.strength is not None else _enum_val(r, "sign"),
         },
     )
     TYPE_REGISTRY[Association] = TypeDescriptor(
@@ -237,10 +240,13 @@ def _register_all() -> None:
         xml_tag="Flow",
         extra_attrs={},
     )
-    TYPE_REGISTRY[Junction] = TypeDescriptor(
-        xml_tag="Junction",
-        extra_attrs={"type": lambda j: j.junction_type.value},
-    )
+    # Junctions are RelationshipConnectors (not Elements/Relationships) and are
+    # serialized by serialize_junction() as <element xsi:type="AndJunction|
+    # OrJunction"> per the XSD (RelationshipConnectorType extends ElementType).
+    # The xml_tag here is retained only for registry completeness; the concrete
+    # AndJunction/OrJunction tags are handled directly by the (de)serializer
+    # (#118).
+    TYPE_REGISTRY[Junction] = TypeDescriptor(xml_tag="Junction")
 
 
 _register_all()

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -19,10 +19,12 @@ except ImportError as exc:
         "lxml is required for XML serialization. Install it with: pip install etcion[xml]"
     ) from exc
 
+from etcion.enums import InfluenceSign, JunctionType
 from etcion.exceptions import InvalidExchangeIdentifierError
 from etcion.metamodel.concepts import Concept, Element, Relationship
 from etcion.metamodel.model import Model
 from etcion.metamodel.profiles import Profile
+from etcion.metamodel.relationships import Influence, Junction
 from etcion.metamodel.viewpoints import View, Viewpoint
 from etcion.serialization.registry import (
     ARCHIMATE_NS,
@@ -206,6 +208,32 @@ def _expanded_attribute_extensions(
         for tgt in targets:
             expanded.setdefault(tgt, {}).update(attrs)
     return expanded
+
+
+# Junctions serialize as <element xsi:type="AndJunction"|"OrJunction"> because
+# the XSD's RelationshipConnectorType extends ElementType (#118).
+_JUNCTION_TYPE_TO_TAG: dict[JunctionType, str] = {
+    JunctionType.AND: "AndJunction",
+    JunctionType.OR: "OrJunction",
+}
+_TAG_TO_JUNCTION_TYPE: dict[str, JunctionType] = {v: k for k, v in _JUNCTION_TYPE_TO_TAG.items()}
+
+# InfluenceSign values that round-trip through @modifier (#118).
+_MODIFIER_TO_SIGN: dict[str, InfluenceSign] = {s.value: s for s in InfluenceSign}
+
+
+def serialize_junction(junction: Junction, *, id_mapper: _IdMapper | None = None) -> etree._Element:
+    """Serialize a Junction as an ``<element>`` node.
+
+    Per the Exchange Format XSD a junction is an element whose ``xsi:type`` is
+    ``AndJunction`` or ``OrJunction`` (RelationshipConnectorType extends
+    ElementType).  It carries no name, documentation, or source/target (#118).
+    """
+    mapper = _default_mapper(id_mapper)
+    el = etree.Element(f"{{{ARCHIMATE_NS}}}element", nsmap=NSMAP)
+    el.set("identifier", mapper.concept(junction.id))
+    el.set(f"{{{XSI_NS}}}type", _JUNCTION_TYPE_TO_TAG[junction.junction_type])
+    return el
 
 
 def serialize_element(elem: Element, *, id_mapper: _IdMapper | None = None) -> etree._Element:
@@ -395,13 +423,25 @@ def serialize_model(
     name_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
     name_el.text = model_name
 
-    elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
-    for elem in model.elements:
-        elements_container.append(serialize_element(elem, id_mapper=mapper))
+    # Junctions are RelationshipConnectors — neither model.elements nor
+    # model.relationships include them, so collect them explicitly (#118).
+    # Junction is the only concrete RelationshipConnector.
+    connectors = [c for c in model.concepts if isinstance(c, Junction)]
 
-    rels_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}relationships")
-    for rel in model.relationships:
-        rels_container.append(serialize_relationship(rel, id_mapper=mapper))
+    # The XSD makes <elements>/<relationships> optional (minOccurs=0) but
+    # non-empty (ElementsType/RelationshipsType require >=1 child), so only emit
+    # a container when it has content (#121).
+    if model.elements or connectors:
+        elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
+        for elem in model.elements:
+            elements_container.append(serialize_element(elem, id_mapper=mapper))
+        for junction in connectors:
+            elements_container.append(serialize_junction(junction, id_mapper=mapper))
+
+    if model.relationships:
+        rels_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}relationships")
+        for rel in model.relationships:
+            rels_container.append(serialize_relationship(rel, id_mapper=mapper))
 
     opaque = getattr(model, "_opaque_xml", [])
     for node in opaque:
@@ -591,17 +631,24 @@ def _from_exchange_id(exchange_id: str) -> str:
 def _deserialize_element(
     node: etree._Element,
     propdef_map: dict[str, tuple[str, type]] | None = None,
-) -> Element | None:
+) -> Concept | None:
     """Deserialize a single ``<element>`` node.
 
     Returns ``None`` and emits a :func:`warnings.warn` when the ArchiMate
     type attribute is not registered in ``_TAG_TO_TYPE``.
+
+    ``<element xsi:type="AndJunction"|"OrJunction">`` nodes are reconstructed as
+    :class:`~etcion.metamodel.relationships.Junction` instances (#118); these
+    carry no name or properties.
 
     ``propdef_map`` maps a propertyDefinitionRef identifier to a tuple of
     ``(attr_name, python_type)`` and is used to reconstruct extended
     attributes.  Pass ``None`` (default) for models without profiles.
     """
     type_attr = node.get(f"{{{XSI_NS}}}type")
+    if type_attr in _TAG_TO_JUNCTION_TYPE:
+        internal_id = _from_exchange_id(node.get("identifier", ""))
+        return Junction(id=internal_id, junction_type=_TAG_TO_JUNCTION_TYPE[type_attr])
     if type_attr not in _TAG_TO_TYPE:
         warnings.warn(f"Unknown element type: {type_attr}", stacklevel=2)
         return None
@@ -632,7 +679,7 @@ def _deserialize_element(
         kwargs["specialization"] = specialization
     if extended_attributes:
         kwargs["extended_attributes"] = extended_attributes
-    return cls(id=internal_id, name=name, description=desc, **kwargs)  # type: ignore[call-arg, return-value]
+    return cls(id=internal_id, name=name, description=desc, **kwargs)  # type: ignore[call-arg]
 
 
 def _deserialize_relationship(
@@ -679,10 +726,22 @@ def _deserialize_relationship(
                 attr_name, attr_type = propdef_map[ref]
                 extended_attributes[attr_name] = _coerce_attr_value(val_node.text, attr_type)
 
-    # Extra attrs (access_mode, sign, etc.) are deferred; Serving has none.
+    # Extra attrs (access_mode, direction, etc.) are deferred; Serving has none.
     kwargs: dict[str, Any] = {}
     if extended_attributes:
         kwargs["extended_attributes"] = extended_attributes
+
+    # Influence folds sign/strength into @modifier (#118): a value matching an
+    # InfluenceSign restores sign; anything else is free-text strength.
+    if cls is Influence:
+        modifier = node.get("modifier")
+        if modifier is not None:
+            sign = _MODIFIER_TO_SIGN.get(modifier)
+            if sign is not None:
+                kwargs["sign"] = sign
+            else:
+                kwargs["strength"] = modifier
+
     return cls(id=internal_id, name=name, source=source, target=target, **kwargs)  # type: ignore[call-arg, return-value]
 
 
@@ -763,9 +822,11 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
             attr_extensions[cls] = {}
         attr_extensions[cls].update(attrs)
 
-    # Phase 2: parse elements (collect, do not add yet); gather specializations
+    # Phase 2: parse elements (collect, do not add yet); gather specializations.
+    # Junctions deserialize here too (as <element xsi:type="*Junction">) but are
+    # RelationshipConnectors with no specialization, so they are skipped below.
     id_map: dict[str, Concept] = {}
-    parsed_elements: list[Element] = []
+    parsed_elements: list[Concept] = []
     specializations: dict[type[Element], list[str]] = {}
     elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
     if elements_node is not None:
@@ -774,7 +835,7 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
             if concept is not None:
                 id_map[el_node.get("identifier", "")] = concept
                 parsed_elements.append(concept)
-                if concept.specialization:
+                if isinstance(concept, Element) and concept.specialization:
                     cls_type = type(concept)
                     if cls_type not in specializations:
                         specializations[cls_type] = []

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -950,11 +950,19 @@ def read_model(path: str | Path) -> Model:
 # Exchange Format XSD validation (FEAT-19.6)
 # ---------------------------------------------------------------------------
 
-_XSD_PATH = Path(__file__).parent / "schema" / "archimate3_Model.xsd"
+# Validate against the most-inclusive bundled schema: archimate3_Diagram.xsd
+# <xs:include>s archimate3_View.xsd, which <xs:include>s archimate3_Model.xsd,
+# which <xs:import>s xml.xsd — so loading Diagram pulls in the whole set and
+# also checks the diagram side (view/node/connection, elementRef/relationshipRef
+# IDREFs), which the Model schema alone does not cover (#119).
+_XSD_PATH = Path(__file__).parent / "schema" / "archimate3_Diagram.xsd"
 
 
 def validate_exchange_format(tree: etree._ElementTree) -> list[str]:
-    """Validate a serialized Exchange Format tree against the bundled XSD.
+    """Validate a serialized Exchange Format tree against the bundled XSD set.
+
+    Loads the full schema set (Model + View + Diagram) so the diagram side is
+    validated as well as the model side (#119).
 
     Returns a list of validation error strings (empty list means valid).
     Raises :exc:`FileNotFoundError` if the XSD has not been bundled yet.

--- a/test/serialization/test_registry.py
+++ b/test/serialization/test_registry.py
@@ -81,18 +81,22 @@ class TestTypeRegistry:
         desc = TYPE_REGISTRY[Access]
         assert "accessType" in desc.extra_attrs
 
-    def test_influence_has_modifier_and_strength(self):
+    def test_influence_has_only_conformant_modifier(self):
+        # The XSD folds sign+strength into the single @modifier; there is no
+        # @strength attribute (#118).
         from etcion.metamodel.relationships import Influence
 
         desc = TYPE_REGISTRY[Influence]
         assert "modifier" in desc.extra_attrs
-        assert "strength" in desc.extra_attrs
+        assert "strength" not in desc.extra_attrs
 
-    def test_junction_has_type_attr(self):
+    def test_junction_has_no_type_attr(self):
+        # Junctions serialize as <element xsi:type="AndJunction|OrJunction">
+        # with no @type attribute (#118).
         from etcion.metamodel.relationships import Junction
 
         desc = TYPE_REGISTRY[Junction]
-        assert "type" in desc.extra_attrs
+        assert "type" not in desc.extra_attrs
 
     def test_registry_count_at_least_57(self):
         """57 concrete types: ~52 elements + ~12 relationships/junction - overlaps."""

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -1346,3 +1346,114 @@ class TestOnInvalidIdPolicy:
         m.add(Serving(source_id=a.id, target_id=b.id))
         tree = serialize_model(m)  # default "raise" — should not raise
         assert validate_exchange_format(tree) == []
+
+
+class TestJunctionSerialization:
+    """Junctions serialize as <element xsi:type='AndJunction'|'OrJunction'> (#118)."""
+
+    def _junction_model(self):
+        from etcion import ModelBuilder
+        from etcion.enums import JunctionType
+
+        b = ModelBuilder()
+        a1 = b.application_component("App1", id="a1")
+        a2 = b.application_component("App2", id="a2")
+        j = b.junction(junction_type=JunctionType.AND)
+        b.serving(a1, j)
+        b.serving(j, a2)
+        return b.build(validate=False), j.id
+
+    def test_junction_emitted_as_element(self):
+        model, jid = self._junction_model()
+        root = serialize_model(model).getroot()
+        types = {el.get(f"{{{XSI_NS}}}type") for el in root.iter(f"{{{ARCHIMATE_NS}}}element")}
+        assert "AndJunction" in types
+
+    def test_junction_has_no_type_attr(self):
+        model, jid = self._junction_model()
+        root = serialize_model(model).getroot()
+        junction_el = next(
+            el
+            for el in root.iter(f"{{{ARCHIMATE_NS}}}element")
+            if el.get(f"{{{XSI_NS}}}type") == "AndJunction"
+        )
+        assert junction_el.get("type") is None
+
+    def test_junction_model_is_xsd_valid(self):
+        model, jid = self._junction_model()
+        assert validate_exchange_format(serialize_model(model)) == []
+
+    def test_junction_round_trips_with_no_dangling_refs(self):
+        from etcion.enums import JunctionType
+        from etcion.metamodel.relationships import Junction
+
+        model, jid = self._junction_model()
+        restored = deserialize_model(serialize_model(model))
+        juncs = [c for c in restored.concepts if isinstance(c, Junction)]
+        assert len(juncs) == 1
+        assert juncs[0].junction_type is JunctionType.AND
+        assert len(restored.relationships) == 2
+        ids = {c.id for c in restored.concepts}
+        assert all(r.source_id in ids and r.target_id in ids for r in restored.relationships)
+
+
+class TestInfluenceModifier:
+    """Influence folds sign/strength into the single conformant @modifier (#118)."""
+
+    def test_strength_emitted_as_modifier_not_strength_attr(self):
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        el = serialize_relationship(Influence(name="i", source=a, target=b, strength="high"))
+        assert el.get("modifier") == "high"
+        assert el.get("strength") is None
+
+    def test_sign_used_as_modifier_when_no_strength(self):
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        el = serialize_relationship(
+            Influence(name="i", source=a, target=b, sign=InfluenceSign.STRONG_POSITIVE)
+        )
+        assert el.get("modifier") == "++"
+        assert el.get("strength") is None
+
+    def test_sign_round_trips_through_modifier(self):
+        m = Model()
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Influence(name="i", source=a, target=b, sign=InfluenceSign.NEGATIVE))
+        restored = deserialize_model(serialize_model(m))
+        inf = next(r for r in restored.relationships if isinstance(r, Influence))
+        assert inf.sign is InfluenceSign.NEGATIVE
+        assert inf.strength is None
+
+    def test_freetext_strength_round_trips_through_modifier(self):
+        m = Model()
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Influence(name="i", source=a, target=b, strength="high"))
+        restored = deserialize_model(serialize_model(m))
+        inf = next(r for r in restored.relationships if isinstance(r, Influence))
+        assert inf.strength == "high"
+        assert inf.sign is None
+
+
+class TestFullSchemaValidation:
+    """validate_exchange_format covers the full Model+View+Diagram schema (#119)."""
+
+    def test_validator_uses_diagram_schema_set(self):
+        from etcion.serialization.xml import _XSD_PATH
+
+        assert _XSD_PATH.name == "archimate3_Diagram.xsd"
+
+    def test_model_with_relationships_validates_end_to_end(self):
+        m = Model()
+        a = BusinessActor(name="A")
+        b = BusinessService(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(source=a, target=b))
+        assert validate_exchange_format(serialize_model(m)) == []

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -254,11 +254,13 @@ class TestSerializeModel:
         assert len(rels) == 1
 
     def test_empty_model(self):
+        # An empty model emits no <elements>/<relationships> containers, since
+        # the XSD forbids empty ones (#121); the result is still schema-valid.
         tree = serialize_model(Model())
         root = tree.getroot()
-        elems = root.find(f"{{{ARCHIMATE_NS}}}elements")
-        assert elems is not None
-        assert len(elems) == 0
+        assert root.find(f"{{{ARCHIMATE_NS}}}elements") is None
+        assert root.find(f"{{{ARCHIMATE_NS}}}relationships") is None
+        assert validate_exchange_format(tree) == []
 
 
 class TestWriteModel_1:


### PR DESCRIPTION
Closes #118. Closes #121. Closes #119.

Three coupled XML-serialization conformance fixes (all touch `serialize_model`), found during the #117 audit. Builds on #117 (merged via #120). Part of the bundle for the upcoming minor release.

## #118 — Junctions were dropped entirely; Influence emitted a bogus attribute

**Junctions.** `Junction` is a `RelationshipConnector` (subclasses `Concept` directly), so it is in neither `model.elements` nor `model.relationships` — `serialize_model` never emitted it, leaving its relationships pointing at **dangling IDREFs** that fail the XSD and Archi import. Now:
- emitted as `<element xsi:type="AndJunction"|"OrJunction">` (the XSD's `RelationshipConnectorType` extends `ElementType`) via a new `serialize_junction()`;
- deserialized back to `Junction(junction_type=...)`;
- relationships attached to junctions now resolve on read instead of being silently dropped.

**Influence.** The XSD folds sign+strength into the single optional `@modifier` (`InfluenceModifierType` = union(`InfluenceStrengthEnum`, `xs:string`)); there is no `@strength` attribute. Now emits one `@modifier` (free-text `strength` if set, else the `sign` value) and round-trips it back to `sign`/`strength` on read.

## #121 — Empty `<relationships>` container failed the XSD

`<elements>`/`<relationships>` are optional in `ModelType` but must be non-empty (`ElementsType`/`RelationshipsType` require ≥1 child). The serializer created both unconditionally, so an element-only (or empty) model produced an empty container that fails validation. Now each container is emitted only when it has content.

## #119 — Validator only loaded the Model XSD

`validate_exchange_format` loaded only `archimate3_Model.xsd`, so the diagram side (`view/node/connection`, `elementRef`/`relationshipRef` IDREFs) went unchecked. The bundled schemas chain via `<xs:include>` (Diagram → View → Model → imports xml.xsd) under one targetNamespace, so `_XSD_PATH` now points at `archimate3_Diagram.xsd`, composing the whole set.

## Tests
- `TestJunctionSerialization` — emitted as element, no `@type`, XSD-valid, round-trips with no dangling refs.
- `TestInfluenceModifier` — strength→`@modifier`, no `@strength`, sign and free-text strength both round-trip.
- `TestFullSchemaValidation` — validator uses the Diagram schema set; model validates end-to-end.
- Updated the registry/`test_empty_model` tests that previously asserted the old non-conformant behavior.

Full suite green; `ruff` + `mypy` clean. (The 2 pre-existing skips remain, incl. the known non-conformant `<views>` block — separate work.)

## Out of scope (newly found, filed separately)
The `etcion:` extension namespace (`profileConstraints`, emitted for dict-form profile constraints) is non-conformant to the bundled `ModelType` under **both** the old and new validator (it was already failing — not a regression). Tracked in a follow-up issue.
