### PR TITLE
fix: restore relationship referential-integrity enforcement (#116)

### DIFF
--- a/src/etcion/metamodel/model.py
+++ b/src/etcion/metamodel/model.py
@@ -259,6 +259,26 @@ class Model:
         self._nx_graph = g
         return g
 
+    def dangling_relationships(self) -> list[Relationship]:
+        """Return relationships whose source or target id is absent from the model.
+
+        A relationship is *dangling* when its ``source_id`` or ``target_id`` is
+        not present in the model's concept map -- i.e. it references a concept
+        that was never added (or has since been removed).  Such edges break
+        referential integrity (Issue #116).
+
+        This is the reusable primitive behind referential-integrity checks in
+        both :meth:`validate` and the deserialization fail-fast path.
+
+        :returns: List of :class:`Relationship` instances, in insertion order,
+            whose endpoints are not both resolvable within this model.
+        """
+        return [
+            r
+            for r in self.relationships
+            if r.source_id not in self._concepts or r.target_id not in self._concepts
+        ]
+
     def connected_to(self, concept: Concept) -> list[Relationship]:
         """Return all relationships where *concept* is source or target (by ID)."""
         return [
@@ -379,6 +399,20 @@ class Model:
         for rel in self.relationships:
             src = self._concepts.get(rel.source_id)
             tgt = self._concepts.get(rel.target_id)
+            # Referential integrity (Issue #116): endpoints absent from the model
+            # are dangling edges.  Report rather than silently skip.  This runs
+            # before junction tracking so a dangling rel is neither permission-
+            # checked nor mistaken for a junction adjacency.
+            missing = [eid for eid, c in ((rel.source_id, src), (rel.target_id, tgt)) if c is None]
+            if missing:
+                err = ValidationError(
+                    f"Relationship '{rel.id}' ({type(rel).__name__}) references "
+                    f"missing endpoint id(s): {missing}"
+                )
+                if strict:
+                    raise err
+                errors.append(err)
+                continue
             src_is_junc = isinstance(src, RelationshipConnector)
             tgt_is_junc = isinstance(tgt, RelationshipConnector)
             # Track Junction adjacency for later validation.
@@ -388,9 +422,6 @@ class Model:
                 junction_rels.setdefault(rel.target_id, []).append(rel)
             # Skip standard permission check for Junction-connected rels.
             if src_is_junc or tgt_is_junc:
-                continue
-            # Endpoints missing from the model cannot be permission-checked.
-            if src is None or tgt is None:
                 continue
             source_type = type(src)
             target_type = type(tgt)

--- a/src/etcion/serialization/json.py
+++ b/src/etcion/serialization/json.py
@@ -180,20 +180,32 @@ def model_to_dict(model: Model, *, include_views: bool = False) -> dict[str, Any
     return result
 
 
-def model_from_dict(data: dict[str, Any]) -> Model:
+def model_from_dict(data: dict[str, Any], *, validate_endpoints: bool = False) -> Model:
     """Reconstruct a :class:`~etcion.metamodel.model.Model` from a JSON-compatible dictionary.
 
     Deserialization is two-phase:
 
     1. **Elements** — each element dict is validated into its correct
-       concrete class and added to the model; an ``id_map`` is built
-       for cross-reference resolution.
+       concrete class and added to the model.
     2. **Relationships** — the ``source`` and ``target`` bare ID strings
-       are resolved to the corresponding :class:`~etcion.metamodel.concepts.Concept`
-       instances before the relationship is validated and added.
+       are stored as ``source_id`` / ``target_id`` (ADR-051) before the
+       relationship is validated and added.
 
-    :raises KeyError: if a ``_type`` value is not present in
-        :data:`_NAME_TO_TYPE` or a relationship references an unknown element ID.
+    Since ADR-051 (Issue #113) relationship endpoints are bare ID strings, so a
+    relationship may reference an id that is not among the loaded concepts.  By
+    default such *dangling* edges load silently (no referential-integrity check),
+    matching the post-0.11 behavior.  Pass ``validate_endpoints=True`` to opt in
+    to a fail-fast check.
+
+    :param validate_endpoints: When ``True``, after all concepts are added the
+        model is checked for dangling relationships (via
+        :meth:`~etcion.metamodel.model.Model.dangling_relationships`) and a
+        :class:`~etcion.exceptions.ValidationError` is raised listing every
+        offending relationship id together with its missing endpoint id(s).
+        Defaults to ``False`` to avoid a breaking change on the patch line.
+    :raises KeyError: if a ``_type`` value is not present in :data:`_NAME_TO_TYPE`.
+    :raises etcion.exceptions.ValidationError: if ``validate_endpoints`` is
+        ``True`` and one or more relationships reference unknown endpoint ids.
     """
     model = Model()
 
@@ -218,5 +230,19 @@ def model_from_dict(data: dict[str, Any]) -> Model:
         rel_data["target_id"] = rel_data.pop("target")
         rel = cls.model_validate(rel_data)
         model.add(rel)
+
+    if validate_endpoints:
+        dangling = model.dangling_relationships()
+        if dangling:
+            from etcion.exceptions import ValidationError
+
+            known_ids = {c.id for c in model.concepts}
+            details = []
+            for rel in dangling:
+                missing = [eid for eid in (rel.source_id, rel.target_id) if eid not in known_ids]
+                details.append(f"'{rel.id}' (missing {missing})")
+            raise ValidationError(
+                "Relationship(s) reference unknown endpoint id(s): " + "; ".join(details)
+            )
 
     return model

--- a/test/metamodel/test_model.py
+++ b/test/metamodel/test_model.py
@@ -902,3 +902,65 @@ class TestElementsWhere:
     def test_is_callable(self, model: Model) -> None:
         """elements_where is callable on Model."""
         assert callable(model.elements_where)
+
+
+class TestDanglingRelationships:
+    """Model.dangling_relationships() referential-integrity primitive (Issue #116)."""
+
+    def test_clean_model_returns_empty(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model(concepts=[actor, proc, rel])
+        assert m.dangling_relationships() == []
+
+    def test_missing_target_detected(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        # Add the relationship but not its target.
+        m = Model(concepts=[actor, rel])
+        assert m.dangling_relationships() == [rel]
+
+    def test_missing_source_detected(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        # Add the relationship but not its source.
+        m = Model(concepts=[proc, rel])
+        assert m.dangling_relationships() == [rel]
+
+
+class TestValidateDanglingEndpoints:
+    """Model.validate() now reports absent endpoints (Issue #116)."""
+
+    def test_absent_endpoint_reported(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model(concepts=[actor, rel])  # target missing
+        errors = m.validate()
+        assert any("missing endpoint" in str(e) for e in errors)
+
+    def test_absent_endpoint_strict_raises(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model(concepts=[actor, rel])  # target missing
+        with pytest.raises(ValidationError):
+            m.validate(strict=True)
+
+    def test_valid_junction_no_false_positive(self) -> None:
+        from etcion.enums import JunctionType
+        from etcion.metamodel.relationships import Junction
+
+        j = Junction(junction_type=JunctionType.OR)
+        a1 = BusinessActor(name="a1")
+        a2 = BusinessActor(name="a2")
+        a3 = BusinessActor(name="a3")
+        r1 = Specialization(name="r1", source=a1, target=j)
+        r2 = Specialization(name="r2", source=a2, target=j)
+        r3 = Specialization(name="r3", source=j, target=a3)
+        m = Model(concepts=[j, a1, a2, a3, r1, r2, r3])
+        errors = m.validate()
+        assert not any("missing endpoint" in str(e) for e in errors)

--- a/test/serialization/test_json.py
+++ b/test/serialization/test_json.py
@@ -384,3 +384,66 @@ class TestProfileAbstractBaseKeys:
         ext = restored.profiles[0].attribute_extensions
         assert ext[Element] == {"tag": str}
         assert ext[BusinessActor] == {"cost_centre": str}
+
+
+class TestReferentialIntegrity:
+    """model_from_dict referential-integrity handling (Issue #116)."""
+
+    @staticmethod
+    def _dangling_data() -> tuple[dict, str, str]:
+        """A serialized model whose Serving relationship dangles (target dropped)."""
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model()
+        m.add(actor)
+        m.add(proc)
+        m.add(rel)
+        data = model_to_dict(m)
+        # Drop the target element from the envelope -> the relationship dangles.
+        data["elements"] = [e for e in data["elements"] if e["id"] != proc.id]
+        return data, rel.id, proc.id
+
+    def test_default_loads_dangling_silently(self) -> None:
+        data, rel_id, target_id = self._dangling_data()
+        m = model_from_dict(data)  # no flag -> no integrity check
+        assert len(m.relationships) == 1
+        assert m.relationships[0].id == rel_id
+        # The dangling endpoint is genuinely absent from the model.
+        assert target_id not in {c.id for c in m.concepts}
+
+    def test_validate_endpoints_raises_naming_offender(self) -> None:
+        from etcion.exceptions import ValidationError
+
+        data, rel_id, target_id = self._dangling_data()
+        with pytest.raises(ValidationError) as exc:
+            model_from_dict(data, validate_endpoints=True)
+        msg = str(exc.value)
+        assert rel_id in msg
+        assert target_id in msg
+
+    def test_validate_endpoints_collects_all_offenders(self) -> None:
+        from etcion.exceptions import ValidationError
+
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel1 = Serving(name="s1", source=actor, target=proc)
+        rel2 = Serving(name="s2", source=proc, target=actor)
+        m = Model()
+        m.add(actor)
+        m.add(proc)
+        m.add(rel1)
+        m.add(rel2)
+        data = model_to_dict(m)
+        # Drop both elements -> both relationships dangle.
+        data["elements"] = []
+        with pytest.raises(ValidationError) as exc:
+            model_from_dict(data, validate_endpoints=True)
+        msg = str(exc.value)
+        assert rel1.id in msg
+        assert rel2.id in msg
+
+    def test_validate_endpoints_clean_model_ok(self, simple_model) -> None:
+        data = model_to_dict(simple_model)
+        m = model_from_dict(data, validate_endpoints=True)
+        assert len(m.relationships) == 1


### PR DESCRIPTION
Closes #116.

Restores the relationship referential-integrity guarantee that the ADR-051 (#113) "endpoints by id" change silently dropped. Builds on #117 (merged via #120). Part of the bundle for the upcoming minor release.

## Root cause
Since 0.13, `model_from_dict` maps wire `source`/`target` onto bare `source_id`/`target_id` with no existence check (pre-0.11 it resolved endpoints to objects, so a missing endpoint raised at load). `Model.validate()` also silently skipped relationships with absent endpoints. Net: dangling edges loaded silently and surfaced late at `model[rel.source_id]`.

## Changes
- **`Model.dangling_relationships() -> list[Relationship]`** — the reusable primitive: every relationship whose `source_id`/`target_id` is not in the model.
- **`Model.validate()`** now reports a `ValidationError` for absent endpoints instead of silently skipping. Junction-connected relationships with present endpoints are unaffected (no false positives) — verified by test.
- **`model_from_dict(env, *, validate_endpoints=False)`** — opt-in fail-fast that raises a `ValidationError` listing every dangling relationship + missing endpoint id(s) in one pass. Default `False` to avoid a second breaking change on the patch line; the stale docstring (claimed `KeyError`) is corrected.

## Decision: opt-in default
`validate_endpoints` defaults to `False` so JSON load keeps post-ADR-051 behavior; callers opt in to fail-fast, or use `validate()`/`dangling_relationships()`. (We can flip the default to `True` in a later minor to fully restore the pre-0.11 contract under semver.)

## Tests
`TestReferentialIntegrity` (json) and `TestDanglingRelationships`/`TestValidateDanglingEndpoints` (model), incl. the junction no-false-positive case. Full suite green; `ruff` + `mypy` clean.

## Note
The XML read path (`read_model`/`deserialize_model`) shares the same `Model.dangling_relationships()`/`validate()` surface; a matching `validate_endpoints` flag there can follow if wanted (kept out of this PR to avoid overlapping the #118/#119 xml.py changes in the sibling branch).
