### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 28 Jun 2026
+
+ArchiMate Exchange Format conformance hardening and a restored
+referential-integrity guarantee. Models built with etcion now produce XML that
+imports cleanly into Archi, and corrupt models fail closer to where they are
+introduced.
+
+### Breaking changes
+
+- **`write_model` now raises by default on non-`NCName` identifiers.** Element
+  and relationship ids, relationship endpoints, and `extended_attributes` keys
+  that are not valid XML `NCName` values previously serialized verbatim,
+  producing XML that fails the Exchange Format XSD and is rejected by Archi on
+  import. `write_model` / `serialize_model` now raise
+  `InvalidExchangeIdentifierError` by default. Pass `on_invalid_id="sanitize"`
+  to auto-rewrite identifiers (keeping ID/IDREF pairings consistent) or
+  `on_invalid_id="allow"` for the previous verbatim behavior (#117).
+- **`Model.validate()` now reports relationships with absent endpoints.** A
+  relationship whose `source_id` / `target_id` is not present in the model now
+  yields a `ValidationError` (and raises under `strict=True`) instead of being
+  silently skipped (#116).
+- **`validate_exchange_format` validates against the full Model + View + Diagram
+  schema set** (previously the Model schema only), so the diagram side and its
+  `elementRef` / `relationshipRef` IDREFs are now checked. Documents that
+  previously passed but contain diagram-side violations will now report
+  errors (#119).
+- **Serialized XML changed for Influence and Junctions.** Influence now emits a
+  single conformant `@modifier` (the XSD has no `@strength`); junctions are
+  emitted as `<element xsi:type="AndJunction"|"OrJunction">`. Consumers parsing
+  etcion's previous output (or comparing against golden files) are affected
+  (#118).
+
+### Added
+
+- `on_invalid_id` policy on `write_model` / `serialize_model`
+  (`"raise"` (default) | `"sanitize"` | `"allow"`) and the
+  `InvalidExchangeIdentifierError` exception it raises (closes #117).
+- `Model.dangling_relationships()` — returns every relationship whose
+  `source_id` / `target_id` is absent from the model (closes #116).
+- `validate_endpoints` (opt-in, default `False`) on `model_from_dict` to
+  fail fast on dangling relationship endpoints during JSON load (closes #116).
+
+### Fixed
+
+- Junctions are now serialized (as `<element xsi:type="AndJunction"|"OrJunction">`)
+  and round-trip correctly. Previously junction concepts were dropped entirely,
+  leaving their relationships pointing at dangling IDREFs that failed XSD
+  validation and Archi import (#118).
+- Influence `sign` and free-text `strength` round-trip through the `@modifier`
+  attribute (#118).
+- Element-only (and empty) models no longer emit an empty `<elements>` /
+  `<relationships>` container, which the XSD rejects (#121).
+
 ## [0.13.0] - 15 Jun 2026
 
 Structural sharing for impact analysis and model editing

--- a/docs/adr/ADR-031-epic019-serialization.md
+++ b/docs/adr/ADR-031-epic019-serialization.md
@@ -212,3 +212,40 @@ Serializing Model to dict (via Pydantic), then dict to XML. Rejected because:
 - Users must import from `etcion.serialization.xml` rather than calling `model.to_xml()`. This is less discoverable but consistent with the library's separation of concerns.
 - The type registry must be kept in sync with the metamodel class hierarchy. A missing registration is a silent bug until a serialization test catches it.
 - Opaque XML preservation (`_opaque_xml`) adds memory overhead proportional to unrecognized content. For models with large view sections, this could be significant.
+
+## Addendum (2026-06-28): NCName-safe identifiers on write (#117)
+
+This addendum amends **Decision 4 (Identifier Format)** and **Decision 8 (XSD Validation)** in response to issue #117. It does not reopen those decisions; it constrains one edge they left open.
+
+### Problem
+
+`Concept.id` accepts any non-empty string (ADR-006: the ArchiMate spec mandates only uniqueness, not a format). On write, `_to_exchange_id()` prepends `id-` and emits the value verbatim into the `identifier` attribute (Decision 4). The Exchange Format XSD types every `identifier`/`source`/`target`/`*Ref` attribute as `xs:ID`/`xs:IDREF`, both derived from XML `NCName` — which forbids `:`, `/`, spaces, and a leading digit, among others.
+
+The result: a user-supplied id such as `api:default/load-template-api` produces XML that fails the bundled XSD. Because validation is opt-in (Decision 8), the library emitted non-conformant XML with no signal. Archi rejected it on import with `cvc-datatype-valid.1.2.1: ... is not a valid value for 'NCName'`.
+
+The in-memory model staying format-agnostic is correct (ADR-006) — a model may only ever be exported to JSON/CSV/graph, where NCName is irrelevant. The constraint is a property of the *Exchange Format serialization target*, so it is enforced at the serialization boundary, not on `Concept.id`.
+
+### Scope of the failure mode
+
+An audit of the serializer found that **every** user-controlled value reaching an `xs:ID`/`xs:IDREF` slot comes from one of four sources. All other user-controlled output (`name`, `documentation`, specialization/property values, model name) lands in `xs:string`, which has no lexical constraint and needs no validation. `xml:lang` is a hard-coded constant. There is therefore no need for a general "validate the whole tree on write" path; the failure surface is closed at these four sources:
+
+| User source | XML slot(s) | XSD type |
+|---|---|---|
+| `Concept.id` | element/relationship `@identifier`; transitively `node/@elementRef`, `connection/@relationshipRef` | `xs:ID` / `xs:IDREF` |
+| `Relationship.source_id` | relationship `@source` | `xs:IDREF` |
+| `Relationship.target_id` | relationship `@target` | `xs:IDREF` |
+| `extended_attributes` keys | `property/@propertyDefinitionRef` **and** `propertyDefinition/@identifier` | `xs:IDREF` + `xs:ID` |
+
+The `extended_attributes` keys are the non-obvious vector: a single malformed key violates the schema in two places (the `propertyDefinition` that declares it and every `property` that references it).
+
+### Decision
+
+`write_model()` / `serialize_model()` gain an `on_invalid_id` policy parameter governing what happens when any of the four sources produces a value that is not a valid `NCName` (after `id-` prefixing):
+
+- `"raise"` (**default**) — collect **all** offending values in one pass and raise a single typed exception (e.g. `InvalidExchangeIdentifierError`) carrying the full `{value: reason}` mapping. The "everything we emit conforms to the bundled XSD" contract holds unless explicitly waived.
+- `"sanitize"` — deterministically rewrite offending values to valid NCNames via the existing bidirectional id-map (Decision 4), collision-safely (a sanitized value that collides with another id must be disambiguated). `source`/`target`/`*Ref` resolve through the same map, so references are fixed consistently for free. The caller's model object is **not** mutated; the rewrite happens only in the emitted tree.
+- `"allow"` — emit verbatim (the pre-#117 behavior), for callers whose downstream consumer is lenient.
+
+Rationale for raise-as-default over silent sanitize: the offending ids are frequently meaningful external-system keys, and silently rewriting them breaks traceability and any external references. Failing loud and early is more debuggable than ids that silently changed shape. The check is a cheap regex over a bounded set, so it is on by default; full XSD validation (Decision 8) remains the authoritative, opt-in superset behind it.
+
+This is intentionally not a Pydantic validator on `Concept.id` — that would violate ADR-006 and reject valid models destined for non-XML formats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "etcion"
-version = "0.13.0"
+version = "0.14.0"
 description = "Architecture as code — build, query, validate, and analyze enterprise architecture models in Python"
 readme = "README.md"
 license = "MIT"

--- a/src/etcion/__init__.py
+++ b/src/etcion/__init__.py
@@ -36,6 +36,7 @@ from etcion.enums import (
 from etcion.exceptions import (
     ConformanceError,
     DerivationError,
+    InvalidExchangeIdentifierError,
     PyArchiError,
     ValidationError,
 )
@@ -227,6 +228,7 @@ __all__: list[str] = [
     "ValidationError",
     "DerivationError",
     "ConformanceError",
+    "InvalidExchangeIdentifierError",
     # conformance (FEAT-01.1)
     "ConformanceProfile",
     "CONFORMANCE",

--- a/src/etcion/exceptions.py
+++ b/src/etcion/exceptions.py
@@ -25,3 +25,28 @@ class DerivationError(PyArchiError):
 
 class ConformanceError(PyArchiError):
     """Raised when a model fails a conformance check against the ArchiMate 3.2 specification."""
+
+
+class InvalidExchangeIdentifierError(PyArchiError):
+    """Raised when XML serialization would emit an identifier that is not a valid NCName.
+
+    The ArchiMate Exchange Format types every ``identifier`` / ``source`` /
+    ``target`` / ``*Ref`` attribute as ``xs:ID`` / ``xs:IDREF``, both derived
+    from XML ``NCName`` (no ``:``, ``/`` or spaces; no leading digit).
+    ``Concept.id``, ``Relationship.source_id`` / ``target_id`` and
+    ``extended_attributes`` keys accept arbitrary strings (ADR-006), so this
+    guards the serialization boundary (ADR-031 addendum, Issue #117).
+
+    :attr:`invalid` maps each offending identifier (as it would appear in the
+    XML, i.e. after the ``id-`` prefix is applied) to the reason it is invalid.
+    """
+
+    def __init__(self, invalid: dict[str, str]) -> None:
+        self.invalid = dict(invalid)
+        detail = "\n".join(f"  {value!r}: {reason}" for value, reason in invalid.items())
+        super().__init__(
+            f"{len(invalid)} identifier(s) are not valid XML NCNames and cannot be written "
+            f"to the ArchiMate Exchange Format:\n{detail}\n"
+            "Fix the offending identifiers, or pass on_invalid_id='sanitize' to rewrite "
+            "them automatically (or on_invalid_id='allow' to emit them verbatim)."
+        )

--- a/src/etcion/metamodel/model.py
+++ b/src/etcion/metamodel/model.py
@@ -259,6 +259,26 @@ class Model:
         self._nx_graph = g
         return g
 
+    def dangling_relationships(self) -> list[Relationship]:
+        """Return relationships whose source or target id is absent from the model.
+
+        A relationship is *dangling* when its ``source_id`` or ``target_id`` is
+        not present in the model's concept map -- i.e. it references a concept
+        that was never added (or has since been removed).  Such edges break
+        referential integrity (Issue #116).
+
+        This is the reusable primitive behind referential-integrity checks in
+        both :meth:`validate` and the deserialization fail-fast path.
+
+        :returns: List of :class:`Relationship` instances, in insertion order,
+            whose endpoints are not both resolvable within this model.
+        """
+        return [
+            r
+            for r in self.relationships
+            if r.source_id not in self._concepts or r.target_id not in self._concepts
+        ]
+
     def connected_to(self, concept: Concept) -> list[Relationship]:
         """Return all relationships where *concept* is source or target (by ID)."""
         return [
@@ -379,6 +399,20 @@ class Model:
         for rel in self.relationships:
             src = self._concepts.get(rel.source_id)
             tgt = self._concepts.get(rel.target_id)
+            # Referential integrity (Issue #116): endpoints absent from the model
+            # are dangling edges.  Report rather than silently skip.  This runs
+            # before junction tracking so a dangling rel is neither permission-
+            # checked nor mistaken for a junction adjacency.
+            missing = [eid for eid, c in ((rel.source_id, src), (rel.target_id, tgt)) if c is None]
+            if missing:
+                err = ValidationError(
+                    f"Relationship '{rel.id}' ({type(rel).__name__}) references "
+                    f"missing endpoint id(s): {missing}"
+                )
+                if strict:
+                    raise err
+                errors.append(err)
+                continue
             src_is_junc = isinstance(src, RelationshipConnector)
             tgt_is_junc = isinstance(tgt, RelationshipConnector)
             # Track Junction adjacency for later validation.
@@ -388,9 +422,6 @@ class Model:
                 junction_rels.setdefault(rel.target_id, []).append(rel)
             # Skip standard permission check for Junction-connected rels.
             if src_is_junc or tgt_is_junc:
-                continue
-            # Endpoints missing from the model cannot be permission-checked.
-            if src is None or tgt is None:
                 continue
             source_type = type(src)
             target_type = type(tgt)

--- a/src/etcion/serialization/json.py
+++ b/src/etcion/serialization/json.py
@@ -180,20 +180,32 @@ def model_to_dict(model: Model, *, include_views: bool = False) -> dict[str, Any
     return result
 
 
-def model_from_dict(data: dict[str, Any]) -> Model:
+def model_from_dict(data: dict[str, Any], *, validate_endpoints: bool = False) -> Model:
     """Reconstruct a :class:`~etcion.metamodel.model.Model` from a JSON-compatible dictionary.
 
     Deserialization is two-phase:
 
     1. **Elements** — each element dict is validated into its correct
-       concrete class and added to the model; an ``id_map`` is built
-       for cross-reference resolution.
+       concrete class and added to the model.
     2. **Relationships** — the ``source`` and ``target`` bare ID strings
-       are resolved to the corresponding :class:`~etcion.metamodel.concepts.Concept`
-       instances before the relationship is validated and added.
+       are stored as ``source_id`` / ``target_id`` (ADR-051) before the
+       relationship is validated and added.
 
-    :raises KeyError: if a ``_type`` value is not present in
-        :data:`_NAME_TO_TYPE` or a relationship references an unknown element ID.
+    Since ADR-051 (Issue #113) relationship endpoints are bare ID strings, so a
+    relationship may reference an id that is not among the loaded concepts.  By
+    default such *dangling* edges load silently (no referential-integrity check),
+    matching the post-0.11 behavior.  Pass ``validate_endpoints=True`` to opt in
+    to a fail-fast check.
+
+    :param validate_endpoints: When ``True``, after all concepts are added the
+        model is checked for dangling relationships (via
+        :meth:`~etcion.metamodel.model.Model.dangling_relationships`) and a
+        :class:`~etcion.exceptions.ValidationError` is raised listing every
+        offending relationship id together with its missing endpoint id(s).
+        Defaults to ``False`` to avoid a breaking change on the patch line.
+    :raises KeyError: if a ``_type`` value is not present in :data:`_NAME_TO_TYPE`.
+    :raises etcion.exceptions.ValidationError: if ``validate_endpoints`` is
+        ``True`` and one or more relationships reference unknown endpoint ids.
     """
     model = Model()
 
@@ -218,5 +230,19 @@ def model_from_dict(data: dict[str, Any]) -> Model:
         rel_data["target_id"] = rel_data.pop("target")
         rel = cls.model_validate(rel_data)
         model.add(rel)
+
+    if validate_endpoints:
+        dangling = model.dangling_relationships()
+        if dangling:
+            from etcion.exceptions import ValidationError
+
+            known_ids = {c.id for c in model.concepts}
+            details = []
+            for rel in dangling:
+                missing = [eid for eid in (rel.source_id, rel.target_id) if eid not in known_ids]
+                details.append(f"'{rel.id}' (missing {missing})")
+            raise ValidationError(
+                "Relationship(s) reference unknown endpoint id(s): " + "; ".join(details)
+            )
 
     return model

--- a/src/etcion/serialization/registry.py
+++ b/src/etcion/serialization/registry.py
@@ -222,11 +222,14 @@ def _register_all() -> None:
         xml_tag="Access",
         extra_attrs={"accessType": lambda r: _enum_val(r, "access_mode")},
     )
+    # The Exchange Format folds sign *and* strength into the single optional
+    # @modifier attribute (InfluenceModifierType = union(InfluenceStrengthEnum,
+    # xs:string)); there is no @strength attribute (#118).  Prefer the free-text
+    # strength when set, else fall back to the sign enum value.
     TYPE_REGISTRY[Influence] = TypeDescriptor(
         xml_tag="Influence",
         extra_attrs={
-            "modifier": lambda r: _enum_val(r, "sign"),
-            "strength": lambda r: r.strength,
+            "modifier": lambda r: r.strength if r.strength is not None else _enum_val(r, "sign"),
         },
     )
     TYPE_REGISTRY[Association] = TypeDescriptor(
@@ -237,10 +240,13 @@ def _register_all() -> None:
         xml_tag="Flow",
         extra_attrs={},
     )
-    TYPE_REGISTRY[Junction] = TypeDescriptor(
-        xml_tag="Junction",
-        extra_attrs={"type": lambda j: j.junction_type.value},
-    )
+    # Junctions are RelationshipConnectors (not Elements/Relationships) and are
+    # serialized by serialize_junction() as <element xsi:type="AndJunction|
+    # OrJunction"> per the XSD (RelationshipConnectorType extends ElementType).
+    # The xml_tag here is retained only for registry completeness; the concrete
+    # AndJunction/OrJunction tags are handled directly by the (de)serializer
+    # (#118).
+    TYPE_REGISTRY[Junction] = TypeDescriptor(xml_tag="Junction")
 
 
 _register_all()

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -6,10 +6,11 @@ Reference: ADR-031.
 from __future__ import annotations
 
 import json
+import re
 import uuid
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 try:
     from lxml import etree
@@ -18,6 +19,7 @@ except ImportError as exc:
         "lxml is required for XML serialization. Install it with: pip install etcion[xml]"
     ) from exc
 
+from etcion.exceptions import InvalidExchangeIdentifierError
 from etcion.metamodel.concepts import Concept, Element, Relationship
 from etcion.metamodel.model import Model
 from etcion.metamodel.profiles import Profile
@@ -81,6 +83,107 @@ def _to_exchange_id(internal_id: str) -> str:
     return internal_id if internal_id.startswith("id-") else f"id-{internal_id}"
 
 
+# Policy governing identifiers that are not valid XML NCNames on write (#117).
+OnInvalidId = Literal["raise", "sanitize", "allow"]
+
+# XML NCName character classes (XML 1.0 NameStartChar/NameChar minus ':').
+# Covers ASCII plus the common Unicode ranges; the rarely-used astral planes
+# (>= U+10000) are omitted for simplicity.
+_NCNAME_START = (
+    "A-Za-z_"
+    "\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02ff\u0370-\u037d\u037f-\u1fff"
+    "\u200c-\u200d\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd"
+)
+_NCNAME_CHAR = _NCNAME_START + "\\-.0-9\u00b7\u0300-\u036f\u203f-\u2040"
+_NCNAME_START_RE = re.compile(f"[{_NCNAME_START}]")
+_NCNAME_CHAR_RE = re.compile(f"[{_NCNAME_CHAR}]")
+_NCNAME_RE = re.compile(f"^[{_NCNAME_START}][{_NCNAME_CHAR}]*$")
+
+
+def _ncname_violation(value: str) -> str | None:
+    """Return a human-readable reason *value* is not a valid NCName, else ``None``."""
+    if value == "":
+        return "empty identifier"
+    if _NCNAME_RE.match(value):
+        return None
+    if not _NCNAME_START_RE.match(value[0]):
+        return f"must start with a letter or underscore, not {value[0]!r}"
+    illegal = sorted({c for c in value if not _NCNAME_CHAR_RE.match(c)})
+    if illegal:
+        chars = ", ".join(repr(c) for c in illegal)
+        return f"contains characters not allowed in an NCName: {chars}"
+    return "not a valid NCName"  # pragma: no cover - defensive
+
+
+def _sanitize_ncname(value: str) -> str:
+    """Rewrite *value* into a valid NCName by replacing illegal characters with ``-``."""
+    out = "".join(c if _NCNAME_CHAR_RE.match(c) else "-" for c in value)
+    if not out or not _NCNAME_START_RE.match(out[0]):
+        out = "_" + out
+    return out
+
+
+class _IdMapper:
+    """Maps internal/raw identifiers to NCName-safe Exchange Format identifiers.
+
+    A single instance is shared across a whole ``serialize_model`` call so that
+    every reference to a given identifier (an element id and the ``source`` /
+    ``target`` / ``elementRef`` / ``relationshipRef`` that point at it, or a
+    ``propertyDefinition`` id and the ``propertyDefinitionRef`` that cites it)
+    resolves to the same output — keeping ID/IDREF pairings intact even when
+    sanitization rewrites a value (ADR-031 addendum, #117).
+
+    When ``sanitize`` is false, invalid identifiers pass through verbatim and are
+    recorded in :attr:`invalid`; the caller decides whether to raise (``"raise"``)
+    or emit them anyway (``"allow"``).
+    """
+
+    def __init__(self, *, sanitize: bool) -> None:
+        self._sanitize = sanitize
+        self._cache: dict[str, str] = {}
+        self._used: set[str] = set()
+        self.invalid: dict[str, str] = {}
+
+    def concept(self, internal_id: str) -> str:
+        """Map a concept's internal id to its (validated) Exchange Format id."""
+        return self._map(_to_exchange_id(internal_id))
+
+    def propdef(self, raw_id: str) -> str:
+        """Map a ``propdef-*`` identifier (built from a user-supplied attr name)."""
+        return self._map(raw_id)
+
+    def _map(self, raw: str) -> str:
+        cached = self._cache.get(raw)
+        if cached is not None:
+            return cached
+        reason = _ncname_violation(raw)
+        if reason is None:
+            # In sanitize mode, dedupe even already-valid ids so a sanitized
+            # value can never collide with a verbatim one (xs:ID uniqueness).
+            result = self._unique(raw) if self._sanitize else raw
+        elif self._sanitize:
+            result = self._unique(_sanitize_ncname(raw))
+        else:
+            self.invalid[raw] = reason
+            result = raw
+        self._cache[raw] = result
+        self._used.add(result)
+        return result
+
+    def _unique(self, candidate: str) -> str:
+        if candidate not in self._used:
+            return candidate
+        suffix = 2
+        while f"{candidate}-{suffix}" in self._used:
+            suffix += 1
+        return f"{candidate}-{suffix}"
+
+
+def _default_mapper(id_mapper: _IdMapper | None) -> _IdMapper:
+    """Return *id_mapper* or a permissive standalone mapper (verbatim, never raises)."""
+    return id_mapper if id_mapper is not None else _IdMapper(sanitize=False)
+
+
 def _expanded_attribute_extensions(
     profile: Profile, present_types: set[type[Concept]]
 ) -> dict[type[Concept], dict[str, Any]]:
@@ -105,11 +208,16 @@ def _expanded_attribute_extensions(
     return expanded
 
 
-def serialize_element(elem: Element) -> etree._Element:
-    """Serialize a single Element to an lxml element node."""
+def serialize_element(elem: Element, *, id_mapper: _IdMapper | None = None) -> etree._Element:
+    """Serialize a single Element to an lxml element node.
+
+    *id_mapper* (internal) carries the NCName-safety policy across a full model
+    serialization; when omitted, identifiers are emitted verbatim (#117).
+    """
+    mapper = _default_mapper(id_mapper)
     desc = TYPE_REGISTRY[type(elem)]
     el = etree.Element(f"{{{ARCHIMATE_NS}}}element", nsmap=NSMAP)
-    el.set("identifier", _to_exchange_id(elem.id))
+    el.set("identifier", mapper.concept(elem.id))
     el.set(f"{{{XSI_NS}}}type", desc.xml_tag)
 
     name_el = etree.SubElement(el, f"{{{ARCHIMATE_NS}}}name")
@@ -136,7 +244,9 @@ def serialize_element(elem: Element) -> etree._Element:
             type_name = TYPE_REGISTRY[type(elem)].xml_tag
             for attr_name, value in elem.extended_attributes.items():
                 prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
-                prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+                prop_el.set(
+                    "propertyDefinitionRef", mapper.propdef(f"propdef-{type_name}-{attr_name}")
+                )
                 val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
                 val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
                 val_el.text = str(value)
@@ -144,7 +254,9 @@ def serialize_element(elem: Element) -> etree._Element:
     return el
 
 
-def serialize_relationship(rel: Relationship) -> etree._Element:
+def serialize_relationship(
+    rel: Relationship, *, id_mapper: _IdMapper | None = None
+) -> etree._Element:
     """Serialize a single Relationship to an lxml element node.
 
     Per ADR-050, ``extended_attributes`` declared on a Relationship are
@@ -152,12 +264,16 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
     propdef-id scheme namespaces by the relationship's xml_tag so collisions
     with element propdefs are not possible (relationship and element xml_tag
     spaces are disjoint).
+
+    *id_mapper* (internal) carries the NCName-safety policy across a full model
+    serialization; when omitted, identifiers are emitted verbatim (#117).
     """
+    mapper = _default_mapper(id_mapper)
     desc = TYPE_REGISTRY[type(rel)]
     el = etree.Element(f"{{{ARCHIMATE_NS}}}relationship", nsmap=NSMAP)
-    el.set("identifier", _to_exchange_id(rel.id))
-    el.set("source", _to_exchange_id(rel.source_id))
-    el.set("target", _to_exchange_id(rel.target_id))
+    el.set("identifier", mapper.concept(rel.id))
+    el.set("source", mapper.concept(rel.source_id))
+    el.set("target", mapper.concept(rel.target_id))
     el.set(f"{{{XSI_NS}}}type", desc.xml_tag)
 
     if rel.name:
@@ -170,7 +286,7 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
         type_name = desc.xml_tag
         for attr_name, value in rel.extended_attributes.items():
             prop_el = etree.SubElement(props_container, f"{{{ARCHIMATE_NS}}}property")
-            prop_el.set("propertyDefinitionRef", f"propdef-{type_name}-{attr_name}")
+            prop_el.set("propertyDefinitionRef", mapper.propdef(f"propdef-{type_name}-{attr_name}"))
             val_el = etree.SubElement(prop_el, f"{{{ARCHIMATE_NS}}}value")
             val_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
             val_el.text = str(value)
@@ -183,7 +299,9 @@ def serialize_relationship(rel: Relationship) -> etree._Element:
     return el
 
 
-def _serialize_view(view: View, parent: etree._Element) -> None:
+def _serialize_view(
+    view: View, parent: etree._Element, *, id_mapper: _IdMapper | None = None
+) -> None:
     """Serialize a single View as a ``<view>`` element appended to *parent*.
 
     Emits ``<node>`` children for every :class:`~etcion.metamodel.concepts.Element`
@@ -193,6 +311,7 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
     Connections whose source or target element is absent from the view are
     silently skipped.
     """
+    mapper = _default_mapper(id_mapper)
     view_id = f"id-view-{uuid.uuid4()}"
     view_el = etree.SubElement(parent, f"{{{ARCHIMATE_NS}}}view")
     view_el.set("identifier", view_id)
@@ -219,7 +338,7 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
         col = index % _columns
         row = index // _columns
         node_id = f"id-node-{uuid.uuid4()}"
-        exchange_id = _to_exchange_id(elem.id)
+        exchange_id = mapper.concept(elem.id)
         elem_exchange_id_to_node_id[exchange_id] = node_id
 
         node_el = etree.SubElement(view_el, f"{{{ARCHIMATE_NS}}}node")
@@ -232,8 +351,8 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
         node_el.set("h", str(_node_h))
 
     for rel in view_relationships:
-        src_exchange_id = _to_exchange_id(rel.source_id)
-        tgt_exchange_id = _to_exchange_id(rel.target_id)
+        src_exchange_id = mapper.concept(rel.source_id)
+        tgt_exchange_id = mapper.concept(rel.target_id)
         src_node_id = elem_exchange_id_to_node_id.get(src_exchange_id)
         tgt_node_id = elem_exchange_id_to_node_id.get(tgt_exchange_id)
         # Skip connections whose endpoints have no node in this view.
@@ -242,14 +361,32 @@ def _serialize_view(view: View, parent: etree._Element) -> None:
 
         conn_el = etree.SubElement(view_el, f"{{{ARCHIMATE_NS}}}connection")
         conn_el.set("identifier", f"id-conn-{uuid.uuid4()}")
-        conn_el.set("relationshipRef", _to_exchange_id(rel.id))
+        conn_el.set("relationshipRef", mapper.concept(rel.id))
         conn_el.set(f"{{{XSI_NS}}}type", "Relationship")
         conn_el.set("source", src_node_id)
         conn_el.set("target", tgt_node_id)
 
 
-def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etree._ElementTree:
-    """Serialize a Model to a complete Exchange Format ElementTree."""
+def serialize_model(
+    model: Model,
+    *,
+    model_name: str = "Untitled Model",
+    on_invalid_id: OnInvalidId = "raise",
+) -> etree._ElementTree:
+    """Serialize a Model to a complete Exchange Format ElementTree.
+
+    *on_invalid_id* governs identifiers that are not valid XML ``NCName`` values
+    once written (element/relationship ids, relationship ``source``/``target``,
+    and ``extended_attributes`` keys — the only user-controlled values that
+    reach ``xs:ID``/``xs:IDREF`` slots; see ADR-031 addendum, #117):
+
+    - ``"raise"`` (default): collect every offending identifier and raise
+      :class:`~etcion.exceptions.InvalidExchangeIdentifierError`.
+    - ``"sanitize"``: rewrite offending identifiers to valid NCNames, keeping
+      ID/IDREF pairings consistent. The *model* object is not mutated.
+    - ``"allow"``: emit identifiers verbatim (pre-#117 behavior).
+    """
+    mapper = _IdMapper(sanitize=(on_invalid_id == "sanitize"))
     root = etree.Element(f"{{{ARCHIMATE_NS}}}model", nsmap=NSMAP)
     root.set("identifier", "id-model-root")
     root.set(f"{{{XSI_NS}}}schemaLocation", ARCHIMATE_SCHEMA_LOCATION)
@@ -260,11 +397,11 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
 
     elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
     for elem in model.elements:
-        elements_container.append(serialize_element(elem))
+        elements_container.append(serialize_element(elem, id_mapper=mapper))
 
     rels_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}relationships")
     for rel in model.relationships:
-        rels_container.append(serialize_relationship(rel))
+        rels_container.append(serialize_relationship(rel, id_mapper=mapper))
 
     opaque = getattr(model, "_opaque_xml", [])
     for node in opaque:
@@ -328,7 +465,7 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
                         raw_value if isinstance(raw_value, type) else raw_value["type"]
                     )
                     pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
-                    pd.set("identifier", f"propdef-{type_name}-{attr_name}")
+                    pd.set("identifier", mapper.propdef(f"propdef-{type_name}-{attr_name}"))
                     pd.set("type", _PY_TO_XSD_TYPE.get(attr_type.__name__, "string"))
                     pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
                     pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
@@ -336,7 +473,7 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
 
         for pid, attr_name in undeclared.items():
             pd = etree.SubElement(propdefs, f"{{{ARCHIMATE_NS}}}propertyDefinition")
-            pd.set("identifier", pid)
+            pd.set("identifier", mapper.propdef(pid))
             pd.set("type", "string")
             pd_name = etree.SubElement(pd, f"{{{ARCHIMATE_NS}}}name")
             pd_name.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
@@ -372,7 +509,12 @@ def serialize_model(model: Model, *, model_name: str = "Untitled Model") -> etre
         views_el = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}views")
         diagrams_el = etree.SubElement(views_el, f"{{{ARCHIMATE_NS}}}diagrams")
         for view in model.views:
-            _serialize_view(view, diagrams_el)
+            _serialize_view(view, diagrams_el, id_mapper=mapper)
+
+    # Under the default "raise" policy, fail once with every offending id rather
+    # than emitting XML that violates the bundled XSD (ADR-031 addendum, #117).
+    if on_invalid_id == "raise" and mapper.invalid:
+        raise InvalidExchangeIdentifierError(mapper.invalid)
 
     return etree.ElementTree(root)
 
@@ -414,9 +556,19 @@ def _collect_constraint_profiles(
     return result
 
 
-def write_model(model: Model, path: str | Path, *, model_name: str = "Untitled Model") -> None:
-    """Write a Model to an XML file in Exchange Format."""
-    tree = serialize_model(model, model_name=model_name)
+def write_model(
+    model: Model,
+    path: str | Path,
+    *,
+    model_name: str = "Untitled Model",
+    on_invalid_id: OnInvalidId = "raise",
+) -> None:
+    """Write a Model to an XML file in Exchange Format.
+
+    *on_invalid_id* controls handling of identifiers that are not valid XML
+    ``NCName`` values; see :func:`serialize_model` (#117).
+    """
+    tree = serialize_model(model, model_name=model_name, on_invalid_id=on_invalid_id)
     etree.indent(tree, space="  ")
     tree.write(
         str(path),

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -19,10 +19,12 @@ except ImportError as exc:
         "lxml is required for XML serialization. Install it with: pip install etcion[xml]"
     ) from exc
 
+from etcion.enums import InfluenceSign, JunctionType
 from etcion.exceptions import InvalidExchangeIdentifierError
 from etcion.metamodel.concepts import Concept, Element, Relationship
 from etcion.metamodel.model import Model
 from etcion.metamodel.profiles import Profile
+from etcion.metamodel.relationships import Influence, Junction
 from etcion.metamodel.viewpoints import View, Viewpoint
 from etcion.serialization.registry import (
     ARCHIMATE_NS,
@@ -206,6 +208,32 @@ def _expanded_attribute_extensions(
         for tgt in targets:
             expanded.setdefault(tgt, {}).update(attrs)
     return expanded
+
+
+# Junctions serialize as <element xsi:type="AndJunction"|"OrJunction"> because
+# the XSD's RelationshipConnectorType extends ElementType (#118).
+_JUNCTION_TYPE_TO_TAG: dict[JunctionType, str] = {
+    JunctionType.AND: "AndJunction",
+    JunctionType.OR: "OrJunction",
+}
+_TAG_TO_JUNCTION_TYPE: dict[str, JunctionType] = {v: k for k, v in _JUNCTION_TYPE_TO_TAG.items()}
+
+# InfluenceSign values that round-trip through @modifier (#118).
+_MODIFIER_TO_SIGN: dict[str, InfluenceSign] = {s.value: s for s in InfluenceSign}
+
+
+def serialize_junction(junction: Junction, *, id_mapper: _IdMapper | None = None) -> etree._Element:
+    """Serialize a Junction as an ``<element>`` node.
+
+    Per the Exchange Format XSD a junction is an element whose ``xsi:type`` is
+    ``AndJunction`` or ``OrJunction`` (RelationshipConnectorType extends
+    ElementType).  It carries no name, documentation, or source/target (#118).
+    """
+    mapper = _default_mapper(id_mapper)
+    el = etree.Element(f"{{{ARCHIMATE_NS}}}element", nsmap=NSMAP)
+    el.set("identifier", mapper.concept(junction.id))
+    el.set(f"{{{XSI_NS}}}type", _JUNCTION_TYPE_TO_TAG[junction.junction_type])
+    return el
 
 
 def serialize_element(elem: Element, *, id_mapper: _IdMapper | None = None) -> etree._Element:
@@ -395,13 +423,25 @@ def serialize_model(
     name_el.set(f"{{{XML_NS}}}lang", DEFAULT_LANG)
     name_el.text = model_name
 
-    elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
-    for elem in model.elements:
-        elements_container.append(serialize_element(elem, id_mapper=mapper))
+    # Junctions are RelationshipConnectors — neither model.elements nor
+    # model.relationships include them, so collect them explicitly (#118).
+    # Junction is the only concrete RelationshipConnector.
+    connectors = [c for c in model.concepts if isinstance(c, Junction)]
 
-    rels_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}relationships")
-    for rel in model.relationships:
-        rels_container.append(serialize_relationship(rel, id_mapper=mapper))
+    # The XSD makes <elements>/<relationships> optional (minOccurs=0) but
+    # non-empty (ElementsType/RelationshipsType require >=1 child), so only emit
+    # a container when it has content (#121).
+    if model.elements or connectors:
+        elements_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}elements")
+        for elem in model.elements:
+            elements_container.append(serialize_element(elem, id_mapper=mapper))
+        for junction in connectors:
+            elements_container.append(serialize_junction(junction, id_mapper=mapper))
+
+    if model.relationships:
+        rels_container = etree.SubElement(root, f"{{{ARCHIMATE_NS}}}relationships")
+        for rel in model.relationships:
+            rels_container.append(serialize_relationship(rel, id_mapper=mapper))
 
     opaque = getattr(model, "_opaque_xml", [])
     for node in opaque:
@@ -591,17 +631,24 @@ def _from_exchange_id(exchange_id: str) -> str:
 def _deserialize_element(
     node: etree._Element,
     propdef_map: dict[str, tuple[str, type]] | None = None,
-) -> Element | None:
+) -> Concept | None:
     """Deserialize a single ``<element>`` node.
 
     Returns ``None`` and emits a :func:`warnings.warn` when the ArchiMate
     type attribute is not registered in ``_TAG_TO_TYPE``.
+
+    ``<element xsi:type="AndJunction"|"OrJunction">`` nodes are reconstructed as
+    :class:`~etcion.metamodel.relationships.Junction` instances (#118); these
+    carry no name or properties.
 
     ``propdef_map`` maps a propertyDefinitionRef identifier to a tuple of
     ``(attr_name, python_type)`` and is used to reconstruct extended
     attributes.  Pass ``None`` (default) for models without profiles.
     """
     type_attr = node.get(f"{{{XSI_NS}}}type")
+    if type_attr in _TAG_TO_JUNCTION_TYPE:
+        internal_id = _from_exchange_id(node.get("identifier", ""))
+        return Junction(id=internal_id, junction_type=_TAG_TO_JUNCTION_TYPE[type_attr])
     if type_attr not in _TAG_TO_TYPE:
         warnings.warn(f"Unknown element type: {type_attr}", stacklevel=2)
         return None
@@ -632,7 +679,7 @@ def _deserialize_element(
         kwargs["specialization"] = specialization
     if extended_attributes:
         kwargs["extended_attributes"] = extended_attributes
-    return cls(id=internal_id, name=name, description=desc, **kwargs)  # type: ignore[call-arg, return-value]
+    return cls(id=internal_id, name=name, description=desc, **kwargs)  # type: ignore[call-arg]
 
 
 def _deserialize_relationship(
@@ -679,10 +726,22 @@ def _deserialize_relationship(
                 attr_name, attr_type = propdef_map[ref]
                 extended_attributes[attr_name] = _coerce_attr_value(val_node.text, attr_type)
 
-    # Extra attrs (access_mode, sign, etc.) are deferred; Serving has none.
+    # Extra attrs (access_mode, direction, etc.) are deferred; Serving has none.
     kwargs: dict[str, Any] = {}
     if extended_attributes:
         kwargs["extended_attributes"] = extended_attributes
+
+    # Influence folds sign/strength into @modifier (#118): a value matching an
+    # InfluenceSign restores sign; anything else is free-text strength.
+    if cls is Influence:
+        modifier = node.get("modifier")
+        if modifier is not None:
+            sign = _MODIFIER_TO_SIGN.get(modifier)
+            if sign is not None:
+                kwargs["sign"] = sign
+            else:
+                kwargs["strength"] = modifier
+
     return cls(id=internal_id, name=name, source=source, target=target, **kwargs)  # type: ignore[call-arg, return-value]
 
 
@@ -763,9 +822,11 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
             attr_extensions[cls] = {}
         attr_extensions[cls].update(attrs)
 
-    # Phase 2: parse elements (collect, do not add yet); gather specializations
+    # Phase 2: parse elements (collect, do not add yet); gather specializations.
+    # Junctions deserialize here too (as <element xsi:type="*Junction">) but are
+    # RelationshipConnectors with no specialization, so they are skipped below.
     id_map: dict[str, Concept] = {}
-    parsed_elements: list[Element] = []
+    parsed_elements: list[Concept] = []
     specializations: dict[type[Element], list[str]] = {}
     elements_node = root.find(f"{{{ARCHIMATE_NS}}}elements")
     if elements_node is not None:
@@ -774,7 +835,7 @@ def deserialize_model(tree: etree._ElementTree) -> Model:
             if concept is not None:
                 id_map[el_node.get("identifier", "")] = concept
                 parsed_elements.append(concept)
-                if concept.specialization:
+                if isinstance(concept, Element) and concept.specialization:
                     cls_type = type(concept)
                     if cls_type not in specializations:
                         specializations[cls_type] = []

--- a/src/etcion/serialization/xml.py
+++ b/src/etcion/serialization/xml.py
@@ -950,11 +950,19 @@ def read_model(path: str | Path) -> Model:
 # Exchange Format XSD validation (FEAT-19.6)
 # ---------------------------------------------------------------------------
 
-_XSD_PATH = Path(__file__).parent / "schema" / "archimate3_Model.xsd"
+# Validate against the most-inclusive bundled schema: archimate3_Diagram.xsd
+# <xs:include>s archimate3_View.xsd, which <xs:include>s archimate3_Model.xsd,
+# which <xs:import>s xml.xsd — so loading Diagram pulls in the whole set and
+# also checks the diagram side (view/node/connection, elementRef/relationshipRef
+# IDREFs), which the Model schema alone does not cover (#119).
+_XSD_PATH = Path(__file__).parent / "schema" / "archimate3_Diagram.xsd"
 
 
 def validate_exchange_format(tree: etree._ElementTree) -> list[str]:
-    """Validate a serialized Exchange Format tree against the bundled XSD.
+    """Validate a serialized Exchange Format tree against the bundled XSD set.
+
+    Loads the full schema set (Model + View + Diagram) so the diagram side is
+    validated as well as the model side (#119).
 
     Returns a list of validation error strings (empty list means valid).
     Raises :exc:`FileNotFoundError` if the XSD has not been bundled yet.

--- a/test/metamodel/test_model.py
+++ b/test/metamodel/test_model.py
@@ -902,3 +902,65 @@ class TestElementsWhere:
     def test_is_callable(self, model: Model) -> None:
         """elements_where is callable on Model."""
         assert callable(model.elements_where)
+
+
+class TestDanglingRelationships:
+    """Model.dangling_relationships() referential-integrity primitive (Issue #116)."""
+
+    def test_clean_model_returns_empty(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model(concepts=[actor, proc, rel])
+        assert m.dangling_relationships() == []
+
+    def test_missing_target_detected(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        # Add the relationship but not its target.
+        m = Model(concepts=[actor, rel])
+        assert m.dangling_relationships() == [rel]
+
+    def test_missing_source_detected(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        # Add the relationship but not its source.
+        m = Model(concepts=[proc, rel])
+        assert m.dangling_relationships() == [rel]
+
+
+class TestValidateDanglingEndpoints:
+    """Model.validate() now reports absent endpoints (Issue #116)."""
+
+    def test_absent_endpoint_reported(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model(concepts=[actor, rel])  # target missing
+        errors = m.validate()
+        assert any("missing endpoint" in str(e) for e in errors)
+
+    def test_absent_endpoint_strict_raises(self) -> None:
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model(concepts=[actor, rel])  # target missing
+        with pytest.raises(ValidationError):
+            m.validate(strict=True)
+
+    def test_valid_junction_no_false_positive(self) -> None:
+        from etcion.enums import JunctionType
+        from etcion.metamodel.relationships import Junction
+
+        j = Junction(junction_type=JunctionType.OR)
+        a1 = BusinessActor(name="a1")
+        a2 = BusinessActor(name="a2")
+        a3 = BusinessActor(name="a3")
+        r1 = Specialization(name="r1", source=a1, target=j)
+        r2 = Specialization(name="r2", source=a2, target=j)
+        r3 = Specialization(name="r3", source=j, target=a3)
+        m = Model(concepts=[j, a1, a2, a3, r1, r2, r3])
+        errors = m.validate()
+        assert not any("missing endpoint" in str(e) for e in errors)

--- a/test/serialization/test_json.py
+++ b/test/serialization/test_json.py
@@ -384,3 +384,66 @@ class TestProfileAbstractBaseKeys:
         ext = restored.profiles[0].attribute_extensions
         assert ext[Element] == {"tag": str}
         assert ext[BusinessActor] == {"cost_centre": str}
+
+
+class TestReferentialIntegrity:
+    """model_from_dict referential-integrity handling (Issue #116)."""
+
+    @staticmethod
+    def _dangling_data() -> tuple[dict, str, str]:
+        """A serialized model whose Serving relationship dangles (target dropped)."""
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel = Serving(name="s", source=actor, target=proc)
+        m = Model()
+        m.add(actor)
+        m.add(proc)
+        m.add(rel)
+        data = model_to_dict(m)
+        # Drop the target element from the envelope -> the relationship dangles.
+        data["elements"] = [e for e in data["elements"] if e["id"] != proc.id]
+        return data, rel.id, proc.id
+
+    def test_default_loads_dangling_silently(self) -> None:
+        data, rel_id, target_id = self._dangling_data()
+        m = model_from_dict(data)  # no flag -> no integrity check
+        assert len(m.relationships) == 1
+        assert m.relationships[0].id == rel_id
+        # The dangling endpoint is genuinely absent from the model.
+        assert target_id not in {c.id for c in m.concepts}
+
+    def test_validate_endpoints_raises_naming_offender(self) -> None:
+        from etcion.exceptions import ValidationError
+
+        data, rel_id, target_id = self._dangling_data()
+        with pytest.raises(ValidationError) as exc:
+            model_from_dict(data, validate_endpoints=True)
+        msg = str(exc.value)
+        assert rel_id in msg
+        assert target_id in msg
+
+    def test_validate_endpoints_collects_all_offenders(self) -> None:
+        from etcion.exceptions import ValidationError
+
+        actor = BusinessActor(name="A")
+        proc = BusinessProcess(name="P")
+        rel1 = Serving(name="s1", source=actor, target=proc)
+        rel2 = Serving(name="s2", source=proc, target=actor)
+        m = Model()
+        m.add(actor)
+        m.add(proc)
+        m.add(rel1)
+        m.add(rel2)
+        data = model_to_dict(m)
+        # Drop both elements -> both relationships dangle.
+        data["elements"] = []
+        with pytest.raises(ValidationError) as exc:
+            model_from_dict(data, validate_endpoints=True)
+        msg = str(exc.value)
+        assert rel1.id in msg
+        assert rel2.id in msg
+
+    def test_validate_endpoints_clean_model_ok(self, simple_model) -> None:
+        data = model_to_dict(simple_model)
+        m = model_from_dict(data, validate_endpoints=True)
+        assert len(m.relationships) == 1

--- a/test/serialization/test_registry.py
+++ b/test/serialization/test_registry.py
@@ -81,18 +81,22 @@ class TestTypeRegistry:
         desc = TYPE_REGISTRY[Access]
         assert "accessType" in desc.extra_attrs
 
-    def test_influence_has_modifier_and_strength(self):
+    def test_influence_has_only_conformant_modifier(self):
+        # The XSD folds sign+strength into the single @modifier; there is no
+        # @strength attribute (#118).
         from etcion.metamodel.relationships import Influence
 
         desc = TYPE_REGISTRY[Influence]
         assert "modifier" in desc.extra_attrs
-        assert "strength" in desc.extra_attrs
+        assert "strength" not in desc.extra_attrs
 
-    def test_junction_has_type_attr(self):
+    def test_junction_has_no_type_attr(self):
+        # Junctions serialize as <element xsi:type="AndJunction|OrJunction">
+        # with no @type attribute (#118).
         from etcion.metamodel.relationships import Junction
 
         desc = TYPE_REGISTRY[Junction]
-        assert "type" in desc.extra_attrs
+        assert "type" not in desc.extra_attrs
 
     def test_registry_count_at_least_57(self):
         """57 concrete types: ~52 elements + ~12 relationships/junction - overlaps."""

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -13,6 +13,7 @@ from lxml import etree
 lxml = pytest.importorskip("lxml")
 
 from etcion.enums import AccessMode, ContentCategory, InfluenceSign, PurposeCategory  # noqa: E402
+from etcion.exceptions import InvalidExchangeIdentifierError  # noqa: E402
 from etcion.metamodel.application import (  # noqa: E402
     ApplicationComponent,
     DataObject,  # noqa: E402
@@ -44,6 +45,8 @@ from etcion.serialization.registry import (  # noqa: E402
 )
 from etcion.serialization.xml import (  # noqa: E402  # noqa: E402  # noqa: E402  # noqa: E402  # noqa: E402
     _from_exchange_id,
+    _ncname_violation,
+    _sanitize_ncname,
     _to_exchange_id,
     deserialize_model,
     read_model,
@@ -1231,3 +1234,113 @@ class TestIssue110ElementKeyedProfile:
         type_by_id = {pd.get("identifier"): pd.get("type") for pd in pd_container}
         # int -> XSD "number"; if Element's str had won we'd see "string".
         assert type_by_id["propdef-ApplicationComponent-_owner"] == "number"
+
+
+class TestNCNameHelpers:
+    """Unit tests for the NCName validation/sanitization primitives (#117)."""
+
+    def test_valid_ncname_returns_none(self) -> None:
+        assert _ncname_violation("id-good_id.1") is None
+
+    def test_colon_and_slash_rejected(self) -> None:
+        reason = _ncname_violation("id-api:default/load")
+        assert reason is not None
+        assert "'/'" in reason and "':'" in reason
+
+    def test_space_rejected(self) -> None:
+        assert _ncname_violation("id-a b") is not None
+
+    def test_empty_rejected(self) -> None:
+        assert _ncname_violation("") == "empty identifier"
+
+    def test_leading_digit_rejected(self) -> None:
+        # A bare value (no id- prefix) starting with a digit is not a valid start.
+        reason = _ncname_violation("3abc")
+        assert reason is not None and "start" in reason
+
+    def test_sanitize_replaces_illegal_chars(self) -> None:
+        assert _sanitize_ncname("id-api:default/load") == "id-api-default-load"
+
+    def test_sanitize_yields_valid_ncname(self) -> None:
+        assert _ncname_violation(_sanitize_ncname("3 weird/id:x")) is None
+
+
+class TestOnInvalidIdPolicy:
+    """write/serialize_model behavior for non-NCName identifiers (#117)."""
+
+    def _model_with_bad_ids(self) -> Model:
+        m = Model()
+        a = ApplicationComponent(id="api:default/load-template-api", name="API")
+        b = BusinessService(id="svc 1", name="Svc")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(id="rel:1", source_id=a.id, target_id=b.id, name="serves"))
+        return m
+
+    def test_raise_is_default(self) -> None:
+        with pytest.raises(InvalidExchangeIdentifierError) as exc_info:
+            serialize_model(self._model_with_bad_ids())
+        # All three offending ids are reported in a single pass.
+        assert len(exc_info.value.invalid) == 3
+
+    def test_write_model_raises_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.xml"
+            with pytest.raises(InvalidExchangeIdentifierError):
+                write_model(self._model_with_bad_ids(), path)
+
+    def test_allow_emits_verbatim(self) -> None:
+        tree = serialize_model(self._model_with_bad_ids(), on_invalid_id="allow")
+        ids = {el.get("identifier") for el in tree.iter() if el.get("identifier")}
+        assert "id-api:default/load-template-api" in ids
+
+    def test_sanitize_produces_xsd_valid_output(self) -> None:
+        tree = serialize_model(self._model_with_bad_ids(), on_invalid_id="sanitize")
+        assert validate_exchange_format(tree) == []
+
+    def test_sanitize_keeps_source_target_consistent(self) -> None:
+        tree = serialize_model(self._model_with_bad_ids(), on_invalid_id="sanitize")
+        root = tree.getroot()
+        # Collect element identifiers and the relationship's source/target.
+        elem_ids = {el.get("identifier") for el in root.iter(f"{{{ARCHIMATE_NS}}}element")}
+        rel = root.find(f"{{{ARCHIMATE_NS}}}relationships/{{{ARCHIMATE_NS}}}relationship")
+        assert rel is not None
+        assert rel.get("source") in elem_ids
+        assert rel.get("target") in elem_ids
+
+    def test_sanitize_does_not_mutate_model(self) -> None:
+        model = self._model_with_bad_ids()
+        serialize_model(model, on_invalid_id="sanitize")
+        # Original ids on the in-memory model are untouched.
+        assert any(e.id == "api:default/load-template-api" for e in model.elements)
+
+    def test_extended_attribute_key_is_validated(self) -> None:
+        # A bad extended_attributes key reaches both an xs:ID and an xs:IDREF.
+        m = Model()
+        m.add(ApplicationComponent(name="App", extended_attributes={"bad key/x": 1}))
+        with pytest.raises(InvalidExchangeIdentifierError) as exc_info:
+            serialize_model(m)
+        assert any("bad key/x" in k for k in exc_info.value.invalid)
+
+    def test_extended_attribute_key_sanitized_consistently(self) -> None:
+        m = Model()
+        a = ApplicationComponent(name="App", extended_attributes={"bad key/x": 1})
+        b = BusinessService(name="Svc")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(source_id=a.id, target_id=b.id))  # keep the model XSD-valid
+        tree = serialize_model(m, on_invalid_id="sanitize")
+        # The property ref and the propertyDefinition id must still match,
+        # which the XSD's IDREF->ID keyref enforces.
+        assert validate_exchange_format(tree) == []
+
+    def test_valid_uuid_model_unaffected(self) -> None:
+        # The default policy must not disturb ordinary UUID-id models.
+        m = Model()
+        a = ApplicationComponent(name="A")
+        b = BusinessService(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(source_id=a.id, target_id=b.id))
+        tree = serialize_model(m)  # default "raise" — should not raise
+        assert validate_exchange_format(tree) == []

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -1346,3 +1346,114 @@ class TestOnInvalidIdPolicy:
         m.add(Serving(source_id=a.id, target_id=b.id))
         tree = serialize_model(m)  # default "raise" — should not raise
         assert validate_exchange_format(tree) == []
+
+
+class TestJunctionSerialization:
+    """Junctions serialize as <element xsi:type='AndJunction'|'OrJunction'> (#118)."""
+
+    def _junction_model(self):
+        from etcion import ModelBuilder
+        from etcion.enums import JunctionType
+
+        b = ModelBuilder()
+        a1 = b.application_component("App1", id="a1")
+        a2 = b.application_component("App2", id="a2")
+        j = b.junction(junction_type=JunctionType.AND)
+        b.serving(a1, j)
+        b.serving(j, a2)
+        return b.build(validate=False), j.id
+
+    def test_junction_emitted_as_element(self):
+        model, jid = self._junction_model()
+        root = serialize_model(model).getroot()
+        types = {el.get(f"{{{XSI_NS}}}type") for el in root.iter(f"{{{ARCHIMATE_NS}}}element")}
+        assert "AndJunction" in types
+
+    def test_junction_has_no_type_attr(self):
+        model, jid = self._junction_model()
+        root = serialize_model(model).getroot()
+        junction_el = next(
+            el
+            for el in root.iter(f"{{{ARCHIMATE_NS}}}element")
+            if el.get(f"{{{XSI_NS}}}type") == "AndJunction"
+        )
+        assert junction_el.get("type") is None
+
+    def test_junction_model_is_xsd_valid(self):
+        model, jid = self._junction_model()
+        assert validate_exchange_format(serialize_model(model)) == []
+
+    def test_junction_round_trips_with_no_dangling_refs(self):
+        from etcion.enums import JunctionType
+        from etcion.metamodel.relationships import Junction
+
+        model, jid = self._junction_model()
+        restored = deserialize_model(serialize_model(model))
+        juncs = [c for c in restored.concepts if isinstance(c, Junction)]
+        assert len(juncs) == 1
+        assert juncs[0].junction_type is JunctionType.AND
+        assert len(restored.relationships) == 2
+        ids = {c.id for c in restored.concepts}
+        assert all(r.source_id in ids and r.target_id in ids for r in restored.relationships)
+
+
+class TestInfluenceModifier:
+    """Influence folds sign/strength into the single conformant @modifier (#118)."""
+
+    def test_strength_emitted_as_modifier_not_strength_attr(self):
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        el = serialize_relationship(Influence(name="i", source=a, target=b, strength="high"))
+        assert el.get("modifier") == "high"
+        assert el.get("strength") is None
+
+    def test_sign_used_as_modifier_when_no_strength(self):
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        el = serialize_relationship(
+            Influence(name="i", source=a, target=b, sign=InfluenceSign.STRONG_POSITIVE)
+        )
+        assert el.get("modifier") == "++"
+        assert el.get("strength") is None
+
+    def test_sign_round_trips_through_modifier(self):
+        m = Model()
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Influence(name="i", source=a, target=b, sign=InfluenceSign.NEGATIVE))
+        restored = deserialize_model(serialize_model(m))
+        inf = next(r for r in restored.relationships if isinstance(r, Influence))
+        assert inf.sign is InfluenceSign.NEGATIVE
+        assert inf.strength is None
+
+    def test_freetext_strength_round_trips_through_modifier(self):
+        m = Model()
+        a = BusinessActor(name="A")
+        b = BusinessActor(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Influence(name="i", source=a, target=b, strength="high"))
+        restored = deserialize_model(serialize_model(m))
+        inf = next(r for r in restored.relationships if isinstance(r, Influence))
+        assert inf.strength == "high"
+        assert inf.sign is None
+
+
+class TestFullSchemaValidation:
+    """validate_exchange_format covers the full Model+View+Diagram schema (#119)."""
+
+    def test_validator_uses_diagram_schema_set(self):
+        from etcion.serialization.xml import _XSD_PATH
+
+        assert _XSD_PATH.name == "archimate3_Diagram.xsd"
+
+    def test_model_with_relationships_validates_end_to_end(self):
+        m = Model()
+        a = BusinessActor(name="A")
+        b = BusinessService(name="B")
+        m.add(a)
+        m.add(b)
+        m.add(Serving(source=a, target=b))
+        assert validate_exchange_format(serialize_model(m)) == []

--- a/test/serialization/test_xml.py
+++ b/test/serialization/test_xml.py
@@ -254,11 +254,13 @@ class TestSerializeModel:
         assert len(rels) == 1
 
     def test_empty_model(self):
+        # An empty model emits no <elements>/<relationships> containers, since
+        # the XSD forbids empty ones (#121); the result is still schema-valid.
         tree = serialize_model(Model())
         root = tree.getroot()
-        elems = root.find(f"{{{ARCHIMATE_NS}}}elements")
-        assert elems is not None
-        assert len(elems) == 0
+        assert root.find(f"{{{ARCHIMATE_NS}}}elements") is None
+        assert root.find(f"{{{ARCHIMATE_NS}}}relationships") is None
+        assert validate_exchange_format(tree) == []
 
 
 class TestWriteModel_1:

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -19,7 +19,7 @@ class TestVersionExposed:
     """etcion.__version__ is publicly accessible and correct."""
 
     def test_version_exposed(self) -> None:
-        assert etcion.__version__ == "0.13.0"
+        assert etcion.__version__ == "0.14.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(etcion.__version__, str)

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -69,7 +69,7 @@ class TestProjectMetadata:
 
     def test_project_version(self) -> None:
         data = _load_toml()
-        assert data["project"]["version"] == "0.13.0"
+        assert data["project"]["version"] == "0.14.0"
 
     def test_requires_python(self) -> None:
         data = _load_toml()


### PR DESCRIPTION
## Summary

ArchiMate Exchange Format conformance hardening and a restored referential-integrity guarantee. Models built with etcion now produce XML that imports cleanly into Archi, and corrupt models fail closer to where they are introduced.

### Breaking changes
- `write_model` raises by default on non-`NCName` identifiers (use `on_invalid_id="sanitize"|"allow"`) (#117)
- `Model.validate()` reports relationships with absent endpoints instead of silently skipping (#116)
- `validate_exchange_format` validates the full Model+View+Diagram schema set (stricter) (#119)
- Serialized XML changed for Influence (single `@modifier`) and Junctions (`AndJunction`/`OrJunction` elements) (#118)

### Added
- `on_invalid_id` + `InvalidExchangeIdentifierError` (#117); `Model.dangling_relationships()` + opt-in `validate_endpoints` (#116)

### Fixed
- Junctions were dropped entirely (dangling IDREFs → failed XSD/Archi import); now serialized and round-tripped (#118)
- Empty `<elements>`/`<relationships>` containers no longer emitted (#121)

See CHANGELOG.md for full notes.

## Closes
Closes #116, closes #117, closes #118, closes #119, closes #121

## Known follow-ups (not in this release)
- #122 — `etcion:profileConstraints` extension element isn't valid against the bundled XSD